### PR TITLE
Added a menu option to hide read feeds in the Drawer/HomeActivity.

### DIFF
--- a/res/menu/drawer.xml
+++ b/res/menu/drawer.xml
@@ -3,6 +3,13 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
     <item
+        android:id="@+id/menu_hide_read_main"
+        android:icon="@drawable/hide_reads"
+        android:showAsAction="always"
+        android:title="@string/context_menu_hide_read"
+        tools:ignore="AlwaysShowAction"/>
+        />
+    <item
         android:id="@+id/menu_edit"
         android:icon="@drawable/content_edit"
         android:showAsAction="always"

--- a/src/net/fred/feedex/utils/PrefUtils.java
+++ b/src/net/fred/feedex/utils/PrefUtils.java
@@ -57,6 +57,7 @@ public class PrefUtils {
     public static final String LAST_SCHEDULED_REFRESH = "lastscheduledrefresh";
 
     public static final String SHOW_READ = "show_read";
+    public static final String SHOW_READ_FEEDS = "show_read_feeds";
 
     public static boolean getBoolean(String key, boolean defValue) {
         SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(MainApplication.getContext());


### PR DESCRIPTION
I added a menu option to hide read feeds in the drawer. I'm sorry to bother you again if this feature has already been rejected before. (It's such a small and obvious change that I thought it must have occurred to people.)

The added button does make the ActionBar look more crowded and doesn't leave room for the "FeedEx" app name on very small displays. I considered putting the button in the drawer itself, maybe centered at the bottom of the list of feeds, but that seems to go against user expectations, since the existing "hide entries" button is in the ActionBar.
