### PR TITLE
fix the ActionBar title in GeneralPrefsActivity

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -60,7 +60,9 @@
                 <data android:mimeType="vnd.android.cursor.item/vnd.feedex.entry" />
             </intent-filter>
         </activity>
-        <activity android:name=".activity.GeneralPrefsActivity" />
+        <activity 
+            android:name=".activity.GeneralPrefsActivity"
+            android:label="@string/menu_settings"/>
         <activity android:name=".widget.WidgetConfigActivity">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />


### PR DESCRIPTION
A small fix to change the ActionBar title to "Settings" in the settings.
