### PR TITLE
Updated italian translation for 1x1 widget

### DIFF
--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -125,6 +125,7 @@
     <string name="green">Verde</string>
     <string name="blue">Blu</string>
     <string name="transparency">Trasparenza</string>
+    <string name="feedex_ticker">Articoli non letti FeedEx</string>
 
     <!-- SETTINGS -->
     <string name="settings_category_refresh">Aggiornamento automatico</string>


### PR DESCRIPTION
Hi, I updated the translation for the 1x1 widget.

Just a note: in other translations, the string is missing, I have to add it to the Italian strings.xml and the diff show that only the English one was changed.
