### PR TITLE
Hide ticker counter if 0

### DIFF
--- a/res/layout/ticker_widget.xml
+++ b/res/layout/ticker_widget.xml
@@ -11,6 +11,7 @@
         android:src="@drawable/icon" />
 
     <ImageView
+        android:id="@+id/feed_ticker_circle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignBottom="@+id/feed_ticker"

--- a/src/net/fred/feedex/widget/TickerWidgetService.java
+++ b/src/net/fred/feedex/widget/TickerWidgetService.java
@@ -27,6 +27,7 @@ import android.content.Intent;
 import android.database.Cursor;
 import android.os.Handler;
 import android.os.IBinder;
+import android.view.View;
 import android.widget.RemoteViews;
 
 import net.fred.feedex.R;
@@ -65,7 +66,16 @@ public class TickerWidgetService extends Service {
         Cursor unread = getContentResolver().query(FeedData.EntryColumns.CONTENT_URI, new String[]{FeedData.ALL_UNREAD_NUMBER}, null, null, null);
         if (unread != null) {
             if (unread.moveToFirst()) {
-                widget.setTextViewText(R.id.feed_ticker, String.valueOf(unread.getInt(0)));
+                int unread_count = unread.getInt(0);
+                if (unread_count > 0) {
+                    widget.setTextViewText(R.id.feed_ticker, String.valueOf(unread_count));
+                    widget.setViewVisibility(R.id.feed_ticker, View.VISIBLE);
+                    widget.setViewVisibility(R.id.feed_ticker_circle, View.VISIBLE);
+                }
+                else {
+                    widget.setViewVisibility(R.id.feed_ticker, View.INVISIBLE);
+                    widget.setViewVisibility(R.id.feed_ticker_circle, View.INVISIBLE);
+                }
             }
             unread.close();
         }


### PR DESCRIPTION
Hi,
I have a bit modified the ticker widget so the counter (and the red circle) are hidden when it is 0, like it work for the message icon and some other application. I also enlarged the FeedEx icon to the full size of the widget so the red circle is superposed to the FeedEx icon when it appears.
