### PR TITLE
Fix French translation.

### DIFF
--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -206,7 +206,7 @@
     <string name="settings_proxy_type">Type</string>
 
     <plurals name="number_of_new_entries">
-        <item quantity="one">Un nouveau article</item>
+        <item quantity="one">Un nouvel article</item>
         <item quantity="other">%d nouveaux articles</item>
     </plurals>
 


### PR DESCRIPTION
Uses "Nouvel article" instead of "Nouveau article".
