### PR TITLE
added possibility to store images to external cache dir

### DIFF
--- a/app/src/main/java/net/fred/feedex/utils/NetworkUtils.java
+++ b/app/src/main/java/net/fred/feedex/utils/NetworkUtils.java
@@ -51,7 +51,8 @@ import java.util.regex.Pattern;
 
 public class NetworkUtils {
 
-    public static final File IMAGE_FOLDER_FILE = new File(MainApplication.getContext().getCacheDir(), "images/");
+    //public static File IMAGE_FOLDER_FILE = new File(MainApplication.getContext().getCacheDir(), "images/");
+    public static File IMAGE_FOLDER_FILE = getPrefsCacheDir();
     public static final String IMAGE_FOLDER = IMAGE_FOLDER_FILE.getAbsolutePath() + '/';
     public static final String TEMP_PREFIX = "TEMP__";
     public static final String ID_SEPARATOR = "__";
@@ -63,11 +64,25 @@ public class NetworkUtils {
         CookieHandler.setDefault(this);
     }};
 
+    private static File getPrefsCacheDir(){
+    	if(PrefUtils.getBoolean("use_external_image_cache",false)){
+    		if(MainApplication.getContext().getExternalCacheDir()==null){
+    			return new File(MainApplication.getContext().getCacheDir(), "images/");
+    		}else{
+    			return new File(MainApplication.getContext().getExternalCacheDir(), "images/");
+    		}
+    	}else{
+        	return new File(MainApplication.getContext().getCacheDir(), "images/");
+    	}
+    }
+    
     public static String getDownloadedImagePath(long entryId, String imgUrl) {
+    	IMAGE_FOLDER_FILE = getPrefsCacheDir();
         return IMAGE_FOLDER + entryId + ID_SEPARATOR + StringUtils.getMd5(imgUrl);
     }
 
     public static String getTempDownloadedImagePath(long entryId, String imgUrl) {
+    	IMAGE_FOLDER_FILE = getPrefsCacheDir();
         return IMAGE_FOLDER + TEMP_PREFIX + entryId + ID_SEPARATOR + StringUtils.getMd5(imgUrl);
     }
 
@@ -109,6 +124,7 @@ public class NetworkUtils {
     }
 
     public static synchronized void deleteEntriesImagesCache(Uri entriesUri, String selection, String[] selectionArgs) {
+    	IMAGE_FOLDER_FILE = getPrefsCacheDir();
         if (IMAGE_FOLDER_FILE.exists()) {
             PictureFilenameFilter filenameFilter = new PictureFilenameFilter();
 
@@ -130,7 +146,7 @@ public class NetworkUtils {
 
     public static boolean needDownloadPictures() {
         String fetchPictureMode = PrefUtils.getString(PrefUtils.PRELOAD_IMAGE_MODE, Constants.FETCH_PICTURE_MODE_WIFI_ONLY_PRELOAD);
-
+        IMAGE_FOLDER_FILE = getPrefsCacheDir();
         boolean downloadPictures = false;
         if (PrefUtils.getBoolean(PrefUtils.DISPLAY_IMAGES, true)) {
             if (Constants.FETCH_PICTURE_MODE_ALWAYS_PRELOAD.equals(fetchPictureMode)) {

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -171,7 +171,9 @@
     <string name="settings_refresh_on_open_description">Descarregarà nous continguts dels canals a
         l\'inici de l\'aplicació.
     </string>
-    <string name="settings_refresh_wifi_only">Actualitza els canals només en Wi-Fi</string>
+    <string name="settings_use_external_image_cache">External image storage</string>
+    <string name="settings_use_external_image_cache_description">Uses the external cache (e.g. SD card) for storing images/media.</string>
+        <string name="settings_refresh_wifi_only">Actualitza els canals només en Wi-Fi</string>
     <string name="settings_refresh_wifi_only_description">Només es descarregaran nous continguts
         dins d\'una connexió Wi-Fi.
     </string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -175,6 +175,8 @@
     <string name="settings_refresh_on_open_description">Obnoví zdroje a načte články při otevření
         aplikace
     </string>
+    <string name="settings_use_external_image_cache">External image storage</string>
+    <string name="settings_use_external_image_cache_description">Uses the external cache (e.g. SD card) for storing images/media.</string>
     <string name="settings_refresh_wifi_only">Obnovovat pouze přes Wi-Fi</string>
     <string name="settings_refresh_wifi_only_description">Automatické obnovení bude spuštěno pouze při dostupném Wi-Fi připojení
     </string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -160,6 +160,8 @@
     <string name="settings_display_entries_fullscreen_description">Einträge automatisch im Vollbild anzeigen</string>
     <string name="settings_refresh_on_open">Feeds beim Öffnen aktualisieren</string>
     <string name="settings_refresh_on_open_description">Aktualisiert alle Feeds beim Öffnen der Anwendung</string>
+    <string name="settings_use_external_image_cache">Externer Bildspeicher</string>
+    <string name="settings_use_external_image_cache_description">Bilder/Medien auf dem externen Speicher (z.B. SD Karte) ablegen.</string>
     <string name="settings_refresh_wifi_only">Nur über WLAN aktualisieren</string>
     <string name="settings_refresh_wifi_only_description">Die automatische Aktualisierung wird nur bei aktiver WLAN-Verbindung durchgeführt</string>
     <string name="settings_visible_feeds">Sichtbare Feeds</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -172,6 +172,8 @@
     <string name="settings_refresh_on_open_description">Actualiza las fuentes al iniciar la
         aplicación.
     </string>
+    <string name="settings_use_external_image_cache">External image storage</string>
+    <string name="settings_use_external_image_cache_description">Uses the external cache (e.g. SD card) for storing images/media.</string>
     <string name="settings_refresh_wifi_only">Actualizar solo en Wi-Fi.</string>
     <string name="settings_refresh_wifi_only_description">Solo se actualizarán las entradas cuando
         se esté conectado a una red Wi-Fi.

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -173,6 +173,8 @@
     <string name="settings_refresh_on_open">Irekitzerakoan jarioak freskatu</string>
     <string name="settings_refresh_on_open_description">Aplikazioa irekitzerakoan jario guztiak freskatzen
         ditu
+    <string name="settings_use_external_image_cache">External image storage</string>
+    <string name="settings_use_external_image_cache_description">Uses the external cache (e.g. SD card) for storing images/media.</string>
     </string>
     <string name="settings_refresh_wifi_only">Freskatu soilik Wi-Fipean</string>
     <string name="settings_refresh_wifi_only_description">Freskatze automatikoa soilik Wi-Fi konexioa eskuragarri badago egingo da

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -168,6 +168,8 @@
     <string name="settings_refresh_on_open">Päivitä käynnistettäessä</string>
     <string name="settings_refresh_on_open_description">Päivitä kaikki syötteet sovelluksen käynnistyessä
     </string>
+    <string name="settings_use_external_image_cache">External image storage</string>
+    <string name="settings_use_external_image_cache_description">Uses the external cache (e.g. SD card) for storing images/media.</string>
     <string name="settings_refresh_wifi_only">Vain Wi-Fi -yhteyden kautta</string>
     <string name="settings_refresh_wifi_only_description">Syötteet päivitetään automaattisesti ainoastaan kun Wi-Fi -yhteys on käytettävissä
     </string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -175,6 +175,8 @@
     <string name="settings_refresh_on_open_description">Met à jour tous les flux à l\'ouverture de
         l\'application
     </string>
+    <string name="settings_use_external_image_cache">External image storage</string>
+    <string name="settings_use_external_image_cache_description">Uses the external cache (e.g. SD card) for storing images/media.</string>
     <string name="settings_refresh_wifi_only">Mise à jour en WiFi uniquement</string>
     <string name="settings_refresh_wifi_only_description">La mise à jour auto ne se fera que si le
         Wifi est activé

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -172,6 +172,8 @@
     <string name="settings_refresh_on_open_description">Aggiorna tutti i feed all\'apertura
         dell\'applicazione
     </string>
+    <string name="settings_use_external_image_cache">External image storage</string>
+    <string name="settings_use_external_image_cache_description">Uses the external cache (e.g. SD card) for storing images/media.</string>
     <string name="settings_refresh_wifi_only">Aggiorna solo in WiFi</string>
     <string name="settings_refresh_wifi_only_description">L\'aggiornamento automatico viene eseguito
         solo quando si è connessi ad una rete WiFi

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -160,6 +160,8 @@
     <string name="settings_display_entries_fullscreen_description">Automatically display entries in fullscreen</string>
     <string name="settings_refresh_on_open">열면 피드 새로 고침</string>
     <string name="settings_refresh_on_open_description">프로그램을 열면 모든 피드 새로 고침</string>
+    <string name="settings_use_external_image_cache">External image storage</string>
+    <string name="settings_use_external_image_cache_description">Uses the external cache (e.g. SD card) for storing images/media.</string>
     <string name="settings_refresh_wifi_only">Wi-Fi에서만 새로 고침</string>
     <string name="settings_refresh_wifi_only_description">Wi-Fi를 사용할 때만 자동으로 새로 고침</string>
     <string name="settings_visible_feeds">피드 모양</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -171,6 +171,8 @@
     <string name="settings_refresh_on_open">Обновлять при запуске</string>
     <string name="settings_refresh_on_open_description">Обновлять все ленты пии запуске приложения
     </string>
+    <string name="settings_use_external_image_cache">External image storage</string>
+    <string name="settings_use_external_image_cache_description">Uses the external cache (e.g. SD card) for storing images/media.</string>
     <string name="settings_refresh_wifi_only">Обновлять только по WiFi</string>
     <string name="settings_refresh_wifi_only_description">Автоматическое обновление будет
         выполняться только при включенном WiFi

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -160,6 +160,8 @@
     <string name="settings_display_entries_fullscreen_description">Аутоматски прикажи уносе преко целог екрана</string>
     <string name="settings_refresh_on_open">Освежи доводе по покретању</string>
     <string name="settings_refresh_on_open_description">Освежи доводе по отварању апликације</string>
+    <string name="settings_use_external_image_cache">External image storage</string>
+    <string name="settings_use_external_image_cache_description">Uses the external cache (e.g. SD card) for storing images/media.</string>
     <string name="settings_refresh_wifi_only">Само преко бежичне везе</string>
     <string name="settings_refresh_wifi_only_description">Аутоматско освежавање само ако је доступна бежична веза</string>
     <string name="settings_visible_feeds">Видљиви доводи</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -159,6 +159,8 @@
     <string name="settings_display_entries_fullscreen_description">Visa inlägg automatiskt i helskärm</string>
     <string name="settings_refresh_on_open">Uppdatera feeds vid start</string>
     <string name="settings_refresh_on_open_description">Uppdatera alla feeds när applikationen öppnas</string>
+    <string name="settings_use_external_image_cache">External image storage</string>
+    <string name="settings_use_external_image_cache_description">Uses the external cache (e.g. SD card) for storing images/media.</string>
     <string name="settings_refresh_wifi_only">Uppdatera endast via Wi-Fi</string>
     <string name="settings_refresh_wifi_only_description">Uppdatera automatisk endast när ett Wi-Fi-nätverk är tillgänglig</string>
     <string name="settings_visible_feeds">Synliga feeds</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -159,6 +159,8 @@
     <string name="settings_display_entries_fullscreen_description">自动在全屏显示消息</string>
     <string name="settings_refresh_on_open">自动刷新</string>
     <string name="settings_refresh_on_open_description">当程序开启时，自动刷新所有订阅</string>
+    <string name="settings_use_external_image_cache">External image storage</string>
+    <string name="settings_use_external_image_cache_description">Uses the external cache (e.g. SD card) for storing images/media.</string>
     <string name="settings_refresh_wifi_only">Wi-Fi环境才自动刷新</string>
     <string name="settings_refresh_wifi_only_description">自动刷新仅在Wi-Fi环境启用</string>
     <string name="settings_visible_feeds">可见源</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -170,6 +170,8 @@
     <string name="settings_display_oldest_first_description">Display oldest entries first</string>
     <string name="settings_display_entries_fullscreen">Auto-fullscreen entries</string>
     <string name="settings_display_entries_fullscreen_description">Automatically display entries in fullscreen</string>
+    <string name="settings_use_external_image_cache">External image storage</string>
+    <string name="settings_use_external_image_cache_description">Uses the external cache (e.g. SD card) for storing images/media.</string>
     <string name="settings_refresh_on_open">Refresh feeds on open</string>
     <string name="settings_refresh_on_open_description">Refreshes all feeds after opening the
         application

--- a/app/src/main/res/xml/general_preferences.xml
+++ b/app/src/main/res/xml/general_preferences.xml
@@ -123,7 +123,14 @@
             android:key="display_entries_fullscreen"
             android:summary="@string/settings_display_entries_fullscreen_description"
             android:title="@string/settings_display_entries_fullscreen" />
-    </PreferenceCategory>
+        <CheckBoxPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="false"
+            android:key="use_external_image_cache"
+            android:summary="@string/settings_use_external_image_cache_description"
+            android:title="@string/settings_use_external_image_cache" />
+        </PreferenceCategory>
 
     <PreferenceCategory
         android:layout_width="wrap_content"


### PR DESCRIPTION
I would be thrilled to see this in fdroid if possible.
My device only has very limited internal storage.
The strings are valid only for english and german. I hope others help in translating.
