### PR TITLE
Remove favicons from the entries list.

### DIFF
--- a/app/src/main/java/net/fred/feedex/adapter/EntriesCursorAdapter.java
+++ b/app/src/main/java/net/fred/feedex/adapter/EntriesCursorAdapter.java
@@ -124,16 +124,6 @@ public class EntriesCursorAdapter extends ResourceCursorAdapter {
 
         holder.starImgView.setVisibility(holder.isFavorite ? View.VISIBLE : View.INVISIBLE);
 
-        if (mShowFeedInfo && mFeedIconPos > -1) {
-            Bitmap bitmap = UiUtils.getFaviconBitmap(feedId, cursor, mFeedIconPos);
-
-            if (bitmap != null) {
-                holder.dateTextView.setCompoundDrawablesWithIntrinsicBounds(new BitmapDrawable(context.getResources(), bitmap), null, null, null);
-            } else {
-                holder.dateTextView.setCompoundDrawablesWithIntrinsicBounds(null, null, null, null);
-            }
-        }
-
         if (mShowFeedInfo && mFeedNamePos > -1) {
             if (feedName != null) {
                 holder.dateTextView.setText(new StringBuilder(feedName).append(Constants.COMMA_SPACE).append(StringUtils.getDateTimeString(cursor.getLong(mDatePos))));


### PR DESCRIPTION
This is a small change to remove the favicons from the entries list view. I think that the favicons are superfluous now that the new big letter icon is always there, and that the list looks a bit cleaner without the favicons.

I suppose the drawer list of feeds could be made consistent, i.e. to show the same round letter icons as the entries list, instead of the favicons.