### PR TITLE
put null if there is no image url in the entry

### DIFF
--- a/mobile/src/main/java/net/fred/feedex/utils/HtmlUtils.java
+++ b/mobile/src/main/java/net/fred/feedex/utils/HtmlUtils.java
@@ -142,6 +142,8 @@ public class HtmlUtils {
                 String imgUrl = matcher.group(1).replace(" ", URL_SPACE);
                 if (isCorrectImage(imgUrl)) {
                     return imgUrl;
+                } else {
+                    return null;
                 }
             }
         }
@@ -153,6 +155,8 @@ public class HtmlUtils {
         for (String imgUrl : imgUrls) {
             if (isCorrectImage(imgUrl)) {
                 return imgUrl;
+            } else {
+                return null;
             }
         }
 


### PR DESCRIPTION
This is a patch to place null in image_url when there is no image url. Without this getMainImageURL in HtmlUtils was returning some links like http://feeds.feedburner.com/~r/androidcentral/~4/8cpbQkzp9gk.
and was displaying white background image like:
![screenshot_2015-03-26-13-26-58](https://cloud.githubusercontent.com/assets/5356702/6854326/8ba9598a-d3be-11e4-8ce6-cf120f7bf072.png)
