### PR TITLE
Authentication Cookie

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "net.fred.feedex"
         minSdkVersion 15
         targetSdkVersion 22
-        versionCode 56
-        versionName "1.8.1"
+        versionCode 57
+        versionName "1.9.1"
     }
 
     compileOptions {

--- a/mobile/src/main/java/net/fred/feedex/activity/EditFeedActivity.java
+++ b/mobile/src/main/java/net/fred/feedex/activity/EditFeedActivity.java
@@ -98,7 +98,7 @@ public class EditFeedActivity extends BaseActivity implements LoaderManager.Load
     static final String FEED_SEARCH_URL = "url";
     static final String FEED_SEARCH_DESC = "contentSnippet";
     private static final String STATE_CURRENT_TAB = "STATE_CURRENT_TAB";
-    private static final String[] FEED_PROJECTION = new String[]{FeedColumns.NAME, FeedColumns.URL, FeedColumns.RETRIEVE_FULLTEXT};
+    private static final String[] FEED_PROJECTION = new String[]{FeedColumns.NAME, FeedColumns.URL, FeedColumns.RETRIEVE_FULLTEXT, FeedColumns.COOKIE_NAME, FeedColumns.COOKIE_VALUE};
     private final ActionMode.Callback mFilterActionModeCallback = new ActionMode.Callback() {
 
         // Called when the action mode is created; startActionMode() was called
@@ -216,6 +216,7 @@ public class EditFeedActivity extends BaseActivity implements LoaderManager.Load
     };
     private TabHost mTabHost;
     private EditText mNameEditText, mUrlEditText;
+    private EditText mCookieNameEditText, mCookieValueEditText;
     private CheckBox mRetrieveFulltextCb;
     private ListView mFiltersListView;
     private FiltersCursorAdapter mFiltersCursorAdapter;
@@ -238,6 +239,8 @@ public class EditFeedActivity extends BaseActivity implements LoaderManager.Load
         mTabHost = (TabHost) findViewById(R.id.tabHost);
         mNameEditText = (EditText) findViewById(R.id.feed_title);
         mUrlEditText = (EditText) findViewById(R.id.feed_url);
+        mCookieNameEditText = (EditText) findViewById(R.id.feed_cookiename);
+        mCookieValueEditText = (EditText) findViewById(R.id.feed_cookievalue);
         mRetrieveFulltextCb = (CheckBox) findViewById(R.id.retrieve_fulltext);
         mFiltersListView = (ListView) findViewById(android.R.id.list);
         View tabWidget = findViewById(android.R.id.tabs);
@@ -292,6 +295,8 @@ public class EditFeedActivity extends BaseActivity implements LoaderManager.Load
                     mNameEditText.setText(cursor.getString(0));
                     mUrlEditText.setText(cursor.getString(1));
                     mRetrieveFulltextCb.setChecked(cursor.getInt(2) == 1);
+                    mCookieNameEditText.setText(cursor.getString(3));
+                    mCookieValueEditText.setText(cursor.getString(4));
                     cursor.close();
                 } else {
                     cursor.close();
@@ -330,9 +335,13 @@ public class EditFeedActivity extends BaseActivity implements LoaderManager.Load
                     values.put(FeedColumns.URL, url);
 
                     String name = mNameEditText.getText().toString();
+                    String cookieName = mCookieNameEditText.getText().toString();
+                    String cookieValue = mCookieValueEditText.getText().toString();
 
                     values.put(FeedColumns.NAME, name.trim().length() > 0 ? name : null);
                     values.put(FeedColumns.RETRIEVE_FULLTEXT, mRetrieveFulltextCb.isChecked() ? 1 : null);
+                    values.put(FeedColumns.COOKIE_NAME, cookieName.trim().length() > 0 ? cookieName : "");
+                    values.put(FeedColumns.COOKIE_VALUE, cookieValue.trim().length() > 0 ? cookieValue : "");
                     values.put(FeedColumns.FETCH_MODE, 0);
                     values.putNull(FeedColumns.ERROR);
 
@@ -414,6 +423,9 @@ public class EditFeedActivity extends BaseActivity implements LoaderManager.Load
 
         final String name = mNameEditText.getText().toString().trim();
         final String urlOrSearch = mUrlEditText.getText().toString().trim();
+        final String cookieName = mCookieNameEditText.getText().toString();
+        final String cookieValue = mCookieValueEditText.getText().toString();
+
         if (urlOrSearch.isEmpty()) {
             Toast.makeText(this, R.string.error_feed_error, Toast.LENGTH_SHORT).show();
         }
@@ -460,7 +472,7 @@ public class EditFeedActivity extends BaseActivity implements LoaderManager.Load
                         builder.setAdapter(adapter, new DialogInterface.OnClickListener() {
                             @Override
                             public void onClick(DialogInterface dialog, int which) {
-                                FeedDataContentProvider.addFeed(EditFeedActivity.this, data.get(which).get(FEED_SEARCH_URL), name.isEmpty() ? data.get(which).get(FEED_SEARCH_TITLE) : name, mRetrieveFulltextCb.isChecked());
+                                FeedDataContentProvider.addFeed(EditFeedActivity.this, data.get(which).get(FEED_SEARCH_URL), name.isEmpty() ? data.get(which).get(FEED_SEARCH_TITLE) : name, mRetrieveFulltextCb.isChecked(), cookieName, cookieValue);
 
                                 setResult(RESULT_OK);
                                 finish();
@@ -475,7 +487,7 @@ public class EditFeedActivity extends BaseActivity implements LoaderManager.Load
                 }
             });
         } else {
-            FeedDataContentProvider.addFeed(EditFeedActivity.this, urlOrSearch, name, mRetrieveFulltextCb.isChecked());
+            FeedDataContentProvider.addFeed(EditFeedActivity.this, urlOrSearch, name, mRetrieveFulltextCb.isChecked(), cookieName, cookieValue);
 
             setResult(RESULT_OK);
             finish();

--- a/mobile/src/main/java/net/fred/feedex/provider/DatabaseHelper.java
+++ b/mobile/src/main/java/net/fred/feedex/provider/DatabaseHelper.java
@@ -61,7 +61,7 @@ import java.io.File;
 class DatabaseHelper extends SQLiteOpenHelper {
 
     private static final String DATABASE_NAME = "FeedEx.db";
-    private static final int DATABASE_VERSION = 8;
+    private static final int DATABASE_VERSION = 9;
 
     private static final String ALTER_TABLE = "ALTER TABLE ";
     private static final String ADD = " ADD ";
@@ -154,6 +154,10 @@ class DatabaseHelper extends SQLiteOpenHelper {
         }
         if (oldVersion < 8) {
             executeCatchedSQL(database, ALTER_TABLE + EntryColumns.TABLE_NAME + ADD + EntryColumns.IMAGE_URL + ' ' + FeedData.TYPE_TEXT);
+        }
+        if (oldVersion < 9) {
+            executeCatchedSQL(database, ALTER_TABLE + FeedColumns.TABLE_NAME + ADD + FeedColumns.COOKIE_NAME + ' ' + FeedData.TYPE_TEXT);
+            executeCatchedSQL(database, ALTER_TABLE + FeedColumns.TABLE_NAME + ADD + FeedColumns.COOKIE_VALUE + ' ' + FeedData.TYPE_TEXT);
         }
     }
 

--- a/mobile/src/main/java/net/fred/feedex/provider/FeedData.java
+++ b/mobile/src/main/java/net/fred/feedex/provider/FeedData.java
@@ -92,6 +92,8 @@ public class FeedData {
 
         public static final String URL = "url";
         public static final String NAME = "name";
+        public static final String COOKIE_NAME = "cookiename";
+        public static final String COOKIE_VALUE = "cookievalue";
         public static final String IS_GROUP = "isgroup";
         public static final String GROUP_ID = "groupid";
         public static final String LAST_UPDATE = "lastupdate";
@@ -113,7 +115,7 @@ public class FeedData {
             return Uri.parse(CONTENT_AUTHORITY + "/feeds/" + feedId);
         }
 
-        public static final String[][] COLUMNS = new String[][]{{_ID, TYPE_PRIMARY_KEY}, {URL, TYPE_TEXT_UNIQUE}, {NAME, TYPE_TEXT}, {IS_GROUP, TYPE_BOOLEAN},
+        public static final String[][] COLUMNS = new String[][]{{_ID, TYPE_PRIMARY_KEY}, {URL, TYPE_TEXT_UNIQUE}, {NAME, TYPE_TEXT},{COOKIE_NAME, TYPE_TEXT},{COOKIE_VALUE, TYPE_TEXT}, {IS_GROUP, TYPE_BOOLEAN},
                 {GROUP_ID, TYPE_EXTERNAL_ID}, {LAST_UPDATE, TYPE_DATE_TIME}, {REAL_LAST_UPDATE, TYPE_DATE_TIME}, {RETRIEVE_FULLTEXT, TYPE_BOOLEAN},
                 {ICON, "BLOB"}, {ERROR, TYPE_TEXT}, {PRIORITY, TYPE_INT}, {FETCH_MODE, TYPE_INT}};
 

--- a/mobile/src/main/java/net/fred/feedex/provider/FeedDataContentProvider.java
+++ b/mobile/src/main/java/net/fred/feedex/provider/FeedDataContentProvider.java
@@ -127,6 +127,10 @@ public class FeedDataContentProvider extends ContentProvider {
     private DatabaseHelper mDatabaseHelper;
 
     public static void addFeed(Context context, String url, String name, boolean retrieveFullText) {
+        addFeed(context, url, name, retrieveFullText, "", "");
+    }
+
+    public static void addFeed(Context context, String url, String name, boolean retrieveFullText, String cookieName, String cookieValue) {
         ContentResolver cr = context.getContentResolver();
 
         if (!url.startsWith(Constants.HTTP_SCHEME) && !url.startsWith(Constants.HTTPS_SCHEME)) {
@@ -150,6 +154,8 @@ public class FeedDataContentProvider extends ContentProvider {
                 values.put(FeedColumns.NAME, name);
             }
             values.put(FeedColumns.RETRIEVE_FULLTEXT, retrieveFullText ? 1 : null);
+            values.put(FeedColumns.COOKIE_NAME, cookieName);
+            values.put(FeedColumns.COOKIE_VALUE, cookieValue);
             cr.insert(FeedColumns.CONTENT_URI, values);
         }
     }

--- a/mobile/src/main/java/net/fred/feedex/service/FetcherService.java
+++ b/mobile/src/main/java/net/fred/feedex/service/FetcherService.java
@@ -294,10 +294,19 @@ public class FetcherService extends IntentService {
                 if (entryCursor.isNull(entryCursor.getColumnIndex(EntryColumns.MOBILIZED_HTML))) { // If we didn't already mobilized it
                     int linkPos = entryCursor.getColumnIndex(EntryColumns.LINK);
                     int abstractHtmlPos = entryCursor.getColumnIndex(EntryColumns.ABSTRACT);
+                    int feedIdPos = entryCursor.getColumnIndex(EntryColumns.FEED_ID);
                     HttpURLConnection connection = null;
 
                     try {
                         String link = entryCursor.getString(linkPos);
+                        String feedId = entryCursor.getString(feedIdPos);
+                        Cursor cursorFeed = cr.query(FeedColumns.CONTENT_URI(feedId), null, null, null, null);
+                        cursorFeed.moveToNext();
+                        int cookieNamePosition = cursorFeed.getColumnIndex(FeedColumns.COOKIE_NAME);
+                        int cookieValuePosition = cursorFeed.getColumnIndex(FeedColumns.COOKIE_VALUE);
+                        String cookieName = cursorFeed.getString(cookieNamePosition);
+                        String cookieValue = cursorFeed.getString(cookieValuePosition);
+                        cursorFeed.close();
 
                         // Try to find a text indicator for better content extraction
                         String contentIndicator = null;
@@ -309,7 +318,7 @@ public class FetcherService extends IntentService {
                             }
                         }
 
-                        connection = NetworkUtils.setupConnection(link);
+                        connection = NetworkUtils.setupConnection(link,cookieName, cookieValue);
 
                         String mobilizedHtml = ArticleTextExtractor.extractContent(connection.getInputStream(), contentIndicator);
 

--- a/mobile/src/main/java/net/fred/feedex/utils/NetworkUtils.java
+++ b/mobile/src/main/java/net/fred/feedex/utils/NetworkUtils.java
@@ -217,11 +217,21 @@ public class NetworkUtils {
         }
     }
 
+    public static HttpURLConnection setupConnection(String url, String cookieName, String cookieValue) throws IOException {
+        String cookie = cookieName + "=" + cookieValue;
+        return setupConnection(new URL(url), cookie);
+    }
+
     public static HttpURLConnection setupConnection(String url) throws IOException {
-        return setupConnection(new URL(url));
+        String cookie = "";
+        return setupConnection(new URL(url), cookie);
     }
 
     public static HttpURLConnection setupConnection(URL url) throws IOException {
+        return setupConnection(url, "");
+    }
+
+    public static HttpURLConnection setupConnection(URL url, String cookie) throws IOException {
         Proxy proxy = null;
 
         ConnectivityManager connectivityManager = (ConnectivityManager) MainApplication.getContext()
@@ -253,6 +263,10 @@ public class NetworkUtils {
 
         HttpURLConnection connection = proxy == null ? (HttpURLConnection) url.openConnection() : (HttpURLConnection) url.openConnection(proxy);
 
+        CookieManager cookieManager = new CookieManager();
+        CookieHandler.setDefault(cookieManager);
+
+        connection.setRequestProperty("Cookie", cookie);
         connection.setDoInput(true);
         connection.setDoOutput(false);
         connection.setRequestProperty("User-agent", "Mozilla/5.0 (compatible) AppleWebKit Chrome Safari"); // some feeds need this to work properly

--- a/mobile/src/main/res/layout/activity_feed_edit.xml
+++ b/mobile/src/main/res/layout/activity_feed_edit.xml
@@ -75,14 +75,55 @@
                         android:hint="@string/optional"
                         android:singleLine="true"/>
 
+                    <TextView
+                        android:id="@+id/name_cookieview"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_below="@id/feed_title"
+                        android:layout_marginLeft="10dp"
+                        android:layout_marginTop="20dp"
+                        android:text="@string/feed_cookie"
+                        android:textAppearance="?android:attr/textAppearanceMedium"
+                        android:textStyle="bold"/>
+
+                    <LinearLayout
+                        android:id="@+id/feed_linear"
+                        android:orientation="horizontal"
+                        android:layout_width="fill_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="10dp"
+                        android:layout_below="@+id/name_cookieview"
+                        android:layout_alignLeft="@+id/name_cookieview"
+                        android:layout_alignStart="@+id/name_cookieview">
+
+                        <EditText
+                            android:id="@+id/feed_cookiename"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:hint="@string/cookiename"
+                            android:singleLine="true"
+                            android:layout_weight="1"/>
+
+                        <EditText
+                            android:id="@+id/feed_cookievalue"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:hint="@string/cookievalue"
+                            android:singleLine="true"
+                            android:layout_weight="1"/>
+
+                    </LinearLayout>
+
                     <CheckBox
                         android:id="@+id/retrieve_fulltext"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_alignParentRight="true"
-                        android:layout_below="@+id/feed_title"
+                        android:layout_below="@+id/feed_linear"
                         android:layout_marginRight="10dp"
                         android:text="@string/get_full_text"/>
+
+
                 </RelativeLayout>
 
                 <RelativeLayout

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -66,6 +66,9 @@
     <string name="feed_url">URL address</string>
     <string name="optional">(optional)</string>
     <string name="website_or_feed">(website or feed)</string>
+    <string name="feed_cookie">Authentication Cookie</string>
+    <string name="cookiename">Name</string>
+    <string name="cookievalue">Value</string>
     <string name="tab_feed_title">Feed</string>
     <string name="tab_filters_title">Filter</string>
     <string name="feed_title">TITLE</string>


### PR DESCRIPTION
For some website (like MediaPart.fr), we need to be log with a paid account to view the full content.
Indeed, the website check for a cookie.

Flym was not able to grab the full content of the news (when "Retrieve the full text" is set), as there was no cookie set.

I add in this fork the ability to manually set a cookie (name/value) for a specified feedEntry.
The user have to grab the cookie information from another browser (on the Android device or not) after he logs on the WebSite. Then he should copy/paste this informations to the FeedEntry configuration on Flym.

Also, I didn't translate the news Strings that I add ( Authentication Cookie, Name, Value).