### PR TITLE
Add textbox to enter custom google news topics. Add german translation.

### DIFF
--- a/mobile/src/main/java/net/fred/feedex/activity/AddGoogleNewsActivity.java
+++ b/mobile/src/main/java/net/fred/feedex/activity/AddGoogleNewsActivity.java
@@ -25,6 +25,7 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.widget.CheckBox;
+import android.widget.EditText;
 
 import net.fred.feedex.R;
 import net.fred.feedex.provider.FeedDataContentProvider;
@@ -41,6 +42,7 @@ public class AddGoogleNewsActivity extends BaseActivity {
 
     private static final int[] CB_IDS = new int[]{R.id.cb_top_stories, R.id.cb_world, R.id.cb_business, R.id.cb_technology, R.id.cb_entertainment,
             R.id.cb_sports, R.id.cb_science, R.id.cb_health};
+    private EditText custom_topic_edit_text;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -50,6 +52,7 @@ public class AddGoogleNewsActivity extends BaseActivity {
         setResult(RESULT_CANCELED);
 
         setContentView(R.layout.activity_add_google_news);
+        custom_topic_edit_text = (EditText) findViewById(R.id.google_news_custom_topic);
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
@@ -79,6 +82,14 @@ public class AddGoogleNewsActivity extends BaseActivity {
                         }
                         FeedDataContentProvider.addFeed(this, url, getString(TOPIC_NAME[topic]), true);
                     }
+                }
+
+                String custom_topic = custom_topic_edit_text.getText().toString();
+                if(!custom_topic.isEmpty())
+                {
+                    String url = "http://news.google.com/news?hl=" + Locale.getDefault().getLanguage() + "&output=rss";
+                    url+="&q="+custom_topic; //TODO: is this safe? What about mutation marks?
+                    FeedDataContentProvider.addFeed(this,url,custom_topic,true);
                 }
 
                 setResult(RESULT_OK);

--- a/mobile/src/main/res/layout/activity_add_google_news.xml
+++ b/mobile/src/main/res/layout/activity_add_google_news.xml
@@ -75,7 +75,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:id="@+id/google_news_custom_topic"
-                android:hint="@string/google_news_custom_topic"/>
+                android:hint="@string/google_news_custom_topic"
+                android:singleLine="true"/>
 
         </LinearLayout>
 

--- a/mobile/src/main/res/layout/activity_add_google_news.xml
+++ b/mobile/src/main/res/layout/activity_add_google_news.xml
@@ -70,7 +70,15 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/google_news_health"/>
+
+            <EditText
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:id="@+id/google_news_custom_topic"
+                android:hint="@string/google_news_custom_topic"/>
+
         </LinearLayout>
+
     </ScrollView>
 
 </RelativeLayout>

--- a/mobile/src/main/res/values-de/strings.xml
+++ b/mobile/src/main/res/values-de/strings.xml
@@ -204,5 +204,6 @@
         <item>Nur über WLAN</item>
         <item>Immer</item>
     </string-array>
+    <string name="google_news_custom_topic">Eigenes Thema</string>
 
 </resources>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -182,6 +182,7 @@
         background
     </string>
     <string name="all_feeds">All feeds (incl. future)</string>
+    <string name="google_news_custom_topic">Enter custom topic</string>
 
     <plurals name="number_of_new_entries">
         <item quantity="one">One new entry</item>


### PR DESCRIPTION
Hi!
I added an EditText to the Google News Activity to allow entering custom topics.
I'm not sure about whether it is safe to append the search query to the url as is. I tested it with umlauts and so far I got no problems.

I hope you find this useful :)