### PR TITLE
Improve tagesschau.de (blind fix)

### DIFF
--- a/Flym/src/main/java/net/fred/feedex/utils/ArticleTextExtractor.java
+++ b/Flym/src/main/java/net/fred/feedex/utils/ArticleTextExtractor.java
@@ -25,9 +25,9 @@ public class ArticleTextExtractor {
 
     // Unlikely candidates
     private static final Pattern UNLIKELY = Pattern.compile("com(bx|ment|munity)|dis(qus|cuss)|e(xtra|[-]?mail)|foot|"
-            + "header|menu|re(mark|ply)|rss|sh(are|outbox)|sponsor"
+            + "header|menu|re(mark|ply)|rss|sh(are|outbox)|social|twitter|facebook|sponsor"
             + "a(d|ll|gegate|rchive|ttachment)|(pag(er|ination))|popup|print|"
-            + "login|si(debar|gn|ngle)");
+            + "login|si(debar|gn|ngle)|hinweis|expla(in|nation)?|metablock");
 
     // Most likely positive candidates
     private static final Pattern POSITIVE = Pattern.compile("(^(body|content|h?entry|main|page|post|text|blog|story|haupt))"


### PR DESCRIPTION
tagesschau.de includes long legal notices regarding embedding of
videos now, a good example is:
https://www.tagesschau.de/ausland/untersuchung-zu-folter-in-der-tuerkei-103.html
This blind fix tries to filter those. (Note: they depublish news items after either 7 or 14 days.)

This also tries to remove social media icons and the comment box
on tagesschau.de