### PR TITLE
Open RSS links from the browser and add Flym to Share menu

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,65 @@
 
 				<category android:name="android.intent.category.LAUNCHER"/>
 			</intent-filter>
+
+			<intent-filter>
+				<action android:name="android.intent.action.SEND"/>
+				<category android:name="android.intent.category.DEFAULT"/>
+				<data android:mimeType="text/plain"/>
+			</intent-filter>
+			<intent-filter>
+				<action android:name="android.intent.action.VIEW" />
+
+				<category android:name="android.intent.category.DEFAULT" />
+				<category android:name="android.intent.category.BROWSABLE" />
+
+				<data android:scheme="http" />
+				<data android:scheme="https" />
+				<data android:host="*" />
+				<data android:pathPattern=".*\\.xml" />
+				<data android:pathPattern=".*\\.rss" />
+				<data android:pathPattern=".*/rss" />
+				<data android:pathPattern=".*rss/*" />
+				<data android:pathPattern=".*/feed" />
+				<data android:pathPattern=".*feed/*" />
+			</intent-filter>
+			<intent-filter>
+				<action android:name="android.intent.action.VIEW" />
+
+				<category android:name="android.intent.category.DEFAULT" />
+				<category android:name="android.intent.category.BROWSABLE" />
+
+				<data android:scheme="http" />
+				<data android:scheme="https" />
+				<data android:host="feeds.feedburner.com" />
+				<data android:host="feedproxy.google.com" />
+				<data android:host="feeds2.feedburner.com" />
+				<data android:host="feedsproxy.google.com" />
+			</intent-filter>
+
+			<intent-filter>
+				<action android:name="android.intent.action.VIEW" />
+
+				<category android:name="android.intent.category.DEFAULT" />
+				<category android:name="android.intent.category.BROWSABLE" />
+
+				<data android:scheme="http" />
+				<data android:scheme="https" />
+				<data android:mimeType="text/xml" />
+				<data android:mimeType="application/rss+xml" />
+				<data android:mimeType="application/rdf+xml" />
+				<data android:mimeType="application/atom+xml" />
+				<data android:mimeType="application/xml" />
+			</intent-filter>
+			<intent-filter>
+				<action android:name="android.intent.action.VIEW" />
+
+				<category android:name="android.intent.category.BROWSABLE" />
+				<category android:name="android.intent.category.DEFAULT" />
+
+				<data android:scheme="feed" />
+				<data android:scheme="rss" />
+			</intent-filter>
 		</activity>
 
 		<activity
@@ -43,6 +102,7 @@
 			android:name="net.frju.flym.ui.about.AboutActivity"
 			android:label="@string/about_flym"
 			android:launchMode="singleTask"/>
+
 
 		<activity
 			android:name="net.frju.flym.ui.settings.SettingsActivity"

--- a/app/src/main/java/net/frju/flym/ui/main/FeedSearchDialog.kt
+++ b/app/src/main/java/net/frju/flym/ui/main/FeedSearchDialog.kt
@@ -146,7 +146,6 @@ class FeedSearchDialog(context: Context, search : String = "", private var defau
         }
 
         if (search.isNotBlank()) {
-            this.setSearchHint(search)
             this.items = arrayListOf() //Do not show default search results before the search is completed
             filter.filter(search.subSequence(0, search.length))
         }

--- a/app/src/main/java/net/frju/flym/ui/main/FeedSearchDialog.kt
+++ b/app/src/main/java/net/frju/flym/ui/main/FeedSearchDialog.kt
@@ -21,17 +21,13 @@ import android.content.Context
 import android.graphics.Color
 import android.os.Bundle
 import android.text.Html
-import android.util.Log
 import android.view.ViewGroup
 import android.webkit.URLUtil
-import android.widget.EditText
 import com.rometools.rome.io.SyndFeedInput
 import com.rometools.rome.io.XmlReader
 import ir.mirrajabi.searchdialog.SimpleSearchDialogCompat
-import ir.mirrajabi.searchdialog.adapters.SearchDialogAdapter
 import ir.mirrajabi.searchdialog.core.BaseFilter
 import ir.mirrajabi.searchdialog.core.SearchResultListener
-import kotlinx.android.synthetic.main.abc_search_view.view.*
 import net.fred.feedex.R
 import net.frju.flym.App
 import net.frju.flym.data.entities.Feed

--- a/app/src/main/java/net/frju/flym/ui/main/FeedSearchDialog.kt
+++ b/app/src/main/java/net/frju/flym/ui/main/FeedSearchDialog.kt
@@ -21,13 +21,17 @@ import android.content.Context
 import android.graphics.Color
 import android.os.Bundle
 import android.text.Html
+import android.util.Log
 import android.view.ViewGroup
 import android.webkit.URLUtil
+import android.widget.EditText
 import com.rometools.rome.io.SyndFeedInput
 import com.rometools.rome.io.XmlReader
 import ir.mirrajabi.searchdialog.SimpleSearchDialogCompat
+import ir.mirrajabi.searchdialog.adapters.SearchDialogAdapter
 import ir.mirrajabi.searchdialog.core.BaseFilter
 import ir.mirrajabi.searchdialog.core.SearchResultListener
+import kotlinx.android.synthetic.main.abc_search_view.view.*
 import net.fred.feedex.R
 import net.frju.flym.App
 import net.frju.flym.data.entities.Feed
@@ -63,7 +67,7 @@ private fun generateDefaultFeeds(context: Context) =
             SearchFeedResult(link, context.getString(name))
         }
 
-class FeedSearchDialog(context: Context, private val defaultFeeds: List<SearchFeedResult> = generateDefaultFeeds(context))
+class FeedSearchDialog(context: Context, search : String = "", private var defaultFeeds: List<SearchFeedResult> = generateDefaultFeeds(context))
     : SimpleSearchDialogCompat<SearchFeedResult>(context,
         context.getString(R.string.feed_search),
         context.getString(R.string.feed_search_hint),
@@ -125,7 +129,7 @@ class FeedSearchDialog(context: Context, private val defaultFeeds: List<SearchFe
                             }
                         }
                     } catch (t: Throwable) {
-						warn("error during feedWithCount search", t)
+                        warn("error during feedWithCount search", t)
                     }
                 } else {
                     array.addAll(defaultFeeds)
@@ -143,6 +147,12 @@ class FeedSearchDialog(context: Context, private val defaultFeeds: List<SearchFe
                 }
                 doAfterFiltering()
             }
+        }
+
+        if (search.isNotBlank()) {
+            this.setSearchHint(search)
+            this.items = arrayListOf() //Do not show default search results before the search is completed
+            filter.filter(search.subSequence(0, search.length))
         }
     }
 

--- a/app/src/main/java/net/frju/flym/ui/main/MainActivity.kt
+++ b/app/src/main/java/net/frju/flym/ui/main/MainActivity.kt
@@ -24,7 +24,6 @@ import android.arch.lifecycle.Observer
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Color
-import android.net.Uri
 import android.os.Bundle
 import android.os.Environment
 import android.support.v4.app.FragmentTransaction
@@ -32,7 +31,6 @@ import android.support.v4.view.GravityCompat
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.PopupMenu
-import android.widget.Toast
 import androidx.core.view.isGone
 import androidx.core.widget.toast
 import com.codekidlabs.storagechooser.StorageChooser
@@ -51,7 +49,6 @@ import net.fred.feedex.R
 import net.frju.flym.App
 import net.frju.flym.data.entities.Feed
 import net.frju.flym.data.entities.FeedWithCount
-import net.frju.flym.data.entities.SearchFeedResult
 import net.frju.flym.data.utils.PrefUtils
 import net.frju.flym.service.AutoRefreshJobService
 import net.frju.flym.ui.about.AboutActivity
@@ -78,7 +75,6 @@ class MainActivity : AppCompatActivity(), MainNavigator, AnkoLogger {
         const val EXTRA_FROM_NOTIF = "EXTRA_FROM_NOTIF"
 
         var isInForeground = false
-        var hasHandeledOnStartIntent = false
 
         private const val TAG_DETAILS = "TAG_DETAILS"
         private const val TAG_MASTER = "TAG_MASTER"
@@ -281,6 +277,7 @@ class MainActivity : AppCompatActivity(), MainNavigator, AnkoLogger {
 
         AutoRefreshJobService.initAutoRefresh(this)
 
+        handleImplicitIntent(intent)
 
     }
 
@@ -296,14 +293,16 @@ class MainActivity : AppCompatActivity(), MainNavigator, AnkoLogger {
 
         //Add feed urls from Open with
         if (intent?.action.equals(Intent.ACTION_VIEW)) {
-            var data : Uri? = intent?.data
-            FeedSearchDialog(this, data.toString()).show()
+            var search : String = intent?.data.toString()
+            var searchDialog = FeedSearchDialog(this, search)
+            searchDialog.show()
         }
         // Add feed urls from Share menu
         if (intent?.action.equals(Intent.ACTION_SEND)) {
-            this.toast(intent?.hasExtra(Intent.EXTRA_TEXT).toString())
-            if (intent?.hasExtra(Intent.EXTRA_TEXT) as Boolean) {
-                FeedSearchDialog(this, intent.getStringExtra(Intent.EXTRA_TEXT)).show()
+            if (intent?.hasExtra(Intent.EXTRA_TEXT) == true) {
+                var search = intent.getStringExtra(Intent.EXTRA_TEXT)
+                var searchDialog = FeedSearchDialog(this, search)
+                searchDialog.show()
             }
         }
 
@@ -313,17 +312,6 @@ class MainActivity : AppCompatActivity(), MainNavigator, AnkoLogger {
             goToEntriesList(feedGroups[0].feedWithCount.feed)
             bottom_navigation.selectedItemId = R.id.unreads
         }
-    }
-
-    override fun onStart() {
-        super.onStart()
-
-        if (!hasHandeledOnStartIntent) {
-            handleImplicitIntent(intent)
-            hasHandeledOnStartIntent = true
-        }
-
-        isInForeground = true
     }
 
     override fun onResume() {

--- a/app/src/main/java/net/frju/flym/ui/main/MainActivity.kt
+++ b/app/src/main/java/net/frju/flym/ui/main/MainActivity.kt
@@ -296,6 +296,7 @@ class MainActivity : AppCompatActivity(), MainNavigator, AnkoLogger {
             var search : String = intent?.data.toString()
             var searchDialog = FeedSearchDialog(this, search)
             searchDialog.show()
+            searchDialog.searchBox.setText(search.subSequence(0, search.length))
         }
         // Add feed urls from Share menu
         if (intent?.action.equals(Intent.ACTION_SEND)) {
@@ -303,6 +304,7 @@ class MainActivity : AppCompatActivity(), MainNavigator, AnkoLogger {
                 var search = intent.getStringExtra(Intent.EXTRA_TEXT)
                 var searchDialog = FeedSearchDialog(this, search)
                 searchDialog.show()
+                searchDialog.searchBox.setText(search.subSequence(0, search.length))
             }
         }
 

--- a/app/src/main/java/net/frju/flym/ui/main/MainActivity.kt
+++ b/app/src/main/java/net/frju/flym/ui/main/MainActivity.kt
@@ -297,6 +297,7 @@ class MainActivity : AppCompatActivity(), MainNavigator, AnkoLogger {
             var searchDialog = FeedSearchDialog(this, search)
             searchDialog.show()
             searchDialog.searchBox.setText(search.subSequence(0, search.length))
+            searchDialog.searchBox.setSelection(search.length)
         }
         // Add feed urls from Share menu
         if (intent?.action.equals(Intent.ACTION_SEND)) {
@@ -305,6 +306,7 @@ class MainActivity : AppCompatActivity(), MainNavigator, AnkoLogger {
                 var searchDialog = FeedSearchDialog(this, search)
                 searchDialog.show()
                 searchDialog.searchBox.setText(search.subSequence(0, search.length))
+                searchDialog.searchBox.setSelection(search.length)
             }
         }
 


### PR DESCRIPTION
Hi,

In the v1 of Flym we could open RSS links from the browser directly in Flym and add a feed using the share menu. This add this feature back.

I displayed the link url in the search box as a searchHint because I didn't find how to add it as if the user typed it.

Thank you for making Flym!