### PR TITLE
storage access framework support for opml im/export

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -111,5 +111,4 @@ dependencies {
 	implementation 'net.dankito.readability4j:readability4j:1.0.1'
 	implementation 'pub.devrel:easypermissions:1.2.0'
 	implementation 'com.rometools:rome-opml:1.10.0'
-	implementation 'com.github.codekidX:storage-chooser:2.0.3'
 }

--- a/app/src/main/java/net/frju/flym/ui/main/MainActivity.kt
+++ b/app/src/main/java/net/frju/flym/ui/main/MainActivity.kt
@@ -19,13 +19,16 @@ package net.frju.flym.ui.main
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.app.AlertDialog
 import android.arch.lifecycle.Observer
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Color
+import android.net.Uri
 import android.os.Bundle
 import android.os.Environment
+import android.provider.OpenableColumns
 import android.support.v4.app.FragmentTransaction
 import android.support.v4.view.GravityCompat
 import android.support.v7.app.AppCompatActivity
@@ -33,7 +36,6 @@ import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.PopupMenu
 import androidx.core.view.isGone
 import androidx.core.widget.toast
-import com.codekidlabs.storagechooser.StorageChooser
 import com.rometools.opml.feed.opml.Attribute
 import com.rometools.opml.feed.opml.Opml
 import com.rometools.opml.feed.opml.Outline
@@ -84,6 +86,8 @@ class MainActivity : AppCompatActivity(), MainNavigator, AnkoLogger {
         private const val AUTO_IMPORT_OPML_REQUEST_CODE = 1
         private const val CHOOSE_OPML_REQUEST_CODE = 2
         private const val EXPORT_OPML_REQUEST_CODE = 3
+        private const val WRITE_OPML_REQUEST_CODE = 4
+        private const val READ_OPML_REQUEST_CODE = 5
         private val NEEDED_PERMS = arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE)
         private val BACKUP_OPML = File(Environment.getExternalStorageDirectory(), "/Flym_auto_backup.opml")
         private const val RETRIEVE_FULLTEXT_OPML_ATTR = "retrieveFullText"
@@ -435,20 +439,9 @@ class MainActivity : AppCompatActivity(), MainNavigator, AnkoLogger {
         if (!EasyPermissions.hasPermissions(this, *NEEDED_PERMS)) {
             EasyPermissions.requestPermissions(this, getString(R.string.storage_request_explanation), CHOOSE_OPML_REQUEST_CODE, *NEEDED_PERMS)
         } else {
-            StorageChooser.Builder()
-                    .withActivity(this)
-                    .withFragmentManager(fragmentManager)
-                    .withMemoryBar(true)
-                    .allowCustomPath(true)
-                    .setType(StorageChooser.FILE_PICKER)
-                    .customFilter(arrayListOf("xml", "opml"))
-                    .build()
-                    .run {
-                        show()
-                        setOnSelectListener {
-                            importOpml(File(it))
-                        }
-                    }
+            val intent = Intent(Intent.ACTION_OPEN_DOCUMENT)
+            intent.type = "text/x-opml"
+            startActivityForResult(intent, READ_OPML_REQUEST_CODE)
         }
     }
 
@@ -457,21 +450,22 @@ class MainActivity : AppCompatActivity(), MainNavigator, AnkoLogger {
         if (!EasyPermissions.hasPermissions(this, *NEEDED_PERMS)) {
             EasyPermissions.requestPermissions(this, getString(R.string.storage_request_explanation), EXPORT_OPML_REQUEST_CODE, *NEEDED_PERMS)
         } else {
-            if (Environment.getExternalStorageState() == Environment.MEDIA_MOUNTED || Environment.getExternalStorageState() == Environment.MEDIA_MOUNTED_READ_ONLY) {
-                doAsync {
-                    try {
-                        val opmlFileName = "Flym_" + System.currentTimeMillis() + ".opml"
-                        val opmlFilePath = Environment.getExternalStorageDirectory().toString() + "/" + opmlFileName
+            val intent = Intent(Intent.ACTION_CREATE_DOCUMENT)
+            intent.type = "text/x-opml"
+            intent.putExtra(Intent.EXTRA_TITLE, "Flym_" + System.currentTimeMillis()+ ".opml")
+            startActivityForResult(intent, WRITE_OPML_REQUEST_CODE)
+        }
+    }
 
-                        exportOpml(FileWriter(opmlFilePath))
-
-                        uiThread { toast(String.format(getString(R.string.message_exported_to), opmlFileName)) }
-                    } catch (e: Exception) {
-                        uiThread { toast(R.string.error_feed_export) }
-                    }
-                }
-            } else {
-                toast(R.string.error_external_storage_not_available)
+    override fun onActivityResult(requestCode: Int, resultCode: Int,
+                                  resultData: Intent?) {
+        if (requestCode == READ_OPML_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
+            if (resultData != null) {
+                importOpml(resultData.data)
+            }
+        } else if (requestCode == WRITE_OPML_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
+            if (resultData != null) {
+                exportOpml(resultData.data)
             }
         }
     }
@@ -482,25 +476,43 @@ class MainActivity : AppCompatActivity(), MainNavigator, AnkoLogger {
             EasyPermissions.requestPermissions(this, getString(R.string.welcome_title_with_opml_import), AUTO_IMPORT_OPML_REQUEST_CODE, *NEEDED_PERMS)
         } else {
             if (BACKUP_OPML.exists()) {
-                importOpml(BACKUP_OPML)
+                importOpml(Uri.fromFile(BACKUP_OPML))
             } else {
                 toast(R.string.cannot_find_feeds)
             }
         }
     }
 
-    private fun importOpml(file: File) {
+    private fun importOpml(uri: Uri) {
         doAsync {
             try {
-                parseOpml(FileReader(file))
+                parseOpml(InputStreamReader(contentResolver.openInputStream(uri)))
             } catch (e: Exception) {
                 try {
                     // We try to remove the opml version number, it may work better in some cases
-                    val fixedReader = StringReader(file.readText().replace("<opml version=['\"][0-9]\\.[0-9]['\"]>".toRegex(), "<opml>"))
+                    var content = BufferedInputStream(contentResolver.openInputStream(uri)).bufferedReader().use { it.readText() }
+                    val fixedReader = StringReader(content.replace("<opml version=['\"][0-9]\\.[0-9]['\"]>".toRegex(), "<opml>"))
                     parseOpml(fixedReader)
                 } catch (e: Exception) {
                     uiThread { toast(R.string.cannot_find_feeds) }
                 }
+            }
+        }
+    }
+
+    private fun exportOpml(uri: Uri) {
+        doAsync {
+            try {
+                exportOpml(OutputStreamWriter(contentResolver.openOutputStream(uri), Charsets.UTF_8))
+                val cursor = contentResolver.query(uri, null, null, null, null)
+                cursor.use {
+                    if (cursor.moveToFirst()) {
+                        var fileName = cursor.getString(cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME))
+                        uiThread { toast(String.format(getString(R.string.message_exported_to), fileName)) }
+                    }
+                }
+            } catch (e: Exception) {
+                uiThread { toast(R.string.error_feed_export) }
             }
         }
     }

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -27,7 +27,6 @@
     <string name="menu_export">Izvezi u OPML</string>
     <string name="storage_request_explanation">Da bi uvoz/izvoz dovoda bio moguć u ili iz datoteke, neophodno je da dozvolite aplikaciji pristup internom skladištu.</string>
     <string name="error_feed_export">Izvoz nije završen uspešno. Proverite da li uređaj ima SD karticu montiranu u sistemu.</string>
-    <string name="error_external_storage_not_available">Spoljna memorija (SD kartica) nije dostupna.</string>
     <string name="feed_search">Pretraga dovoda</string>
     <string name="feed_search_hint">Unesite vezu do dovoda ili ključnu reč</string>
     <string name="feed_added">Dovod je dodat u listu</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -29,9 +29,6 @@
     <string name="error_feed_export">No s\'ha pogut exportar el fitxer. Comproveu la memòria
         externa.
     </string>
-    <string name="error_external_storage_not_available">The external storage (e.g. SD-card) is not
-        available.
-    </string>
     <string name="feed_search">Cerca canals</string>
 	<string name="feed_search_hint">Enter feed link or keyword</string>
     <string name="feed_added">Feed added to the list</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -51,9 +51,6 @@
     <string name="error_feed_export">Export selhal. Ujistěte se, že se na připojenou SD kartu
         dá zapisovat.
     </string>
-    <string name="error_external_storage_not_available">Externí úložný prostor (např. SD karta) není
-        dostupný.
-    </string>
     <string name="feed_search">Prohledat zdroj</string>
 	<string name="feed_search_hint">Enter feed link or keyword</string>
     <string name="feed_added">Feed added to the list</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -50,7 +50,6 @@
     <string name="menu_export">Nach OPML exportieren</string>
     <string name="storage_request_explanation">Um Feeds aus/in eine(r) Datei zu importieren/exportieren, muss das Programm die Berechtigung haben auf den Speicher zuzugreifen.</string>
     <string name="error_feed_export">Der Export ist fehlgeschlagen. Stelle sicher, dass eine beschreibbare SD-Karte eingelegt ist.</string>
-    <string name="error_external_storage_not_available">Der externe Speicher (z.B. SD-Karte) ist nicht verfügbar.</string>
     <string name="feed_search">Feed-Suche</string>
 	<string name="feed_search_hint">Feed-Link oder Suchbegriff eingeben</string>
     <string name="feed_added">Feed zur Liste hinzugefügt</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -49,8 +49,6 @@
     <string name="error_feed_export">No se ha podido exportar las fuentes. Compruebe los permisos en
         la tarjeta SD.
     </string>
-    <string name="error_external_storage_not_available">El almacenaje externo no está disponible.
-    </string>
     <string name="feed_search">Buscar fuentes</string>
 	<string name="feed_search_hint">Enter feed link or keyword</string>
     <string name="feed_added">Feed added to the list</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -50,9 +50,6 @@
     <string name="error_feed_export">Esportazioak huts egin du. Egiaztatu idatz daitekeen SD-txartel bat
         muntatuta duzula.
     </string>
-	<string name="error_external_storage_not_available">Kanpoko biltegia (adib. SD-txartela) ez dago
-        eskuragarri.
-    </string>
     <string name="feed_search">Jarioen bilaketa</string>
 	<string name="feed_search_hint">Idatz ezazu lotura edo gako hitza</string>
     <string name="feed_added">Jarioa zerrendara gehitu da</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -48,8 +48,6 @@
     <string name="storage_request_explanation">Voidaksesi tuoda tai viedä tiedoston, sinun täytyy antaa sovellukselle käyttölupa tallennusmuistin sisältöön.</string>
     <string name="error_feed_export">Vienti epäonnistui. Varmista, että SD-kortille voidaan kirjoittaa.
     </string>
-    <string name="error_external_storage_not_available">Ulkoinen tallenusväline (esim. SD-kortti) ei ole saatavilla.
-    </string>
     <string name="feed_search">Hae syötteitä</string>
 	<string name="feed_search_hint">Enter feed link or keyword</string>
     <string name="feed_added">Feed added to the list</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -48,7 +48,6 @@
     <string name="menu_export">Exporter vers OPML</string>
     <string name="storage_request_explanation">Pour pouvoir importer ou exporter les flux dans un fichier, vous devez authoriser l\'application à accéder à la mémoire de stockage.</string>
     <string name="error_feed_export">L\'export a échoué. Assurez-vous d\'avoir une carte SD montée et autorisée en écriture.</string>
-    <string name="error_external_storage_not_available">Le stockage externe (comme la carte SD) n\'est pas disponible.</string>
     <string name="feed_search">Recherche de flux</string>
     <string name="feed_search_hint">Entrez un lien de flux ou un mot-clé</string>
     <string name="feed_added">Flux ajouté à votre liste</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -48,7 +48,6 @@
     <string name="menu_export">Esporta file OPML</string>
     <string name="storage_request_explanation">Per poter importare/esportare i feed da/su file, è necessario consentire all\'applicazione di accedere alla memoria di archiviazione.</string>
     <string name="error_feed_export">L\'esportazione è fallita. Controllare di avere una scheda SD scrivibile e correttamente montata.</string>
-    <string name="error_external_storage_not_available">L\'archivio esterno (per esempio la scheda SD) non è disponibile.</string>
     <string name="feed_search">Ricerca feed</string>
     <string name="feed_search_hint">Inserisci il link di un feed o una parola chiave</string>
     <string name="feed_added">Feed aggiunto alla lista</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -48,7 +48,6 @@
     <string name="menu_export">OPML로 내보내기</string>
     <string name="storage_request_explanation">To be able to import or export the feeds from or to a file, you must allow the application to access to the storage memory.</string>
     <string name="error_feed_export">내보내기가 실패했습니다. 쓰기 가능한 SD 카드 저장소가 마운트되어 있는지 확인하십시오.</string>
-    <string name="error_external_storage_not_available">외부 저장소(SD 카드 따위)가 없습니다.</string>
     <string name="feed_search">피드 검색</string>
     <string name="feed_search_hint">Enter feed link or keyword</string>
     <string name="feed_added">Feed added to the list</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -27,7 +27,6 @@
     <string name="menu_export">Exporteren naar OPML</string>
     <string name="storage_request_explanation">Als je feeds van/naar een bestand wilt importeren/exporteren, dan moet je de app toegang geven tot je opslag.</string>
     <string name="error_feed_export">Het exporteren is mislukt. Zorg ervoor dat je een beschrijfbare SD-kaart in de telefoon hebt gestopt.</string>
-    <string name="error_external_storage_not_available">De externe opslag (bijv. de SD-kaart) is niet beschikbaar.</string>
     <string name="feed_search">Feeds zoeken</string>
     <string name="feed_search_hint">Voeg een feedlink toe of een zoekterm in</string>
     <string name="feed_added">Feed toegevoegd aan lijst</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -47,7 +47,6 @@
     <string name="menu_export">Exportar para OPML</string>
     <string name="storage_request_explanation">Para conseguir importar or exportar os feeds de ou para um arquivo, você deve permitir que o aplicativo acesse o armazenamento interno.</string>
     <string name="error_feed_export">A exportação falhou. Tenha certeza que você possui um cartão SD montado.</string>
-    <string name="error_external_storage_not_available">O armazenamento externo (Ex. cartão SD) não está disponível.</string>
     <string name="feed_search">Busca no Feed</string>
 	<string name="feed_search_hint">Enter feed link or keyword</string>
     <string name="feed_added">Feed added to the list</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -50,9 +50,6 @@
     <string name="error_feed_export">Экспорт не удался. Удостоверьтесь, что карта памяти имеет
         возможность записи.
     </string>
-    <string name="error_external_storage_not_available">Внешнее хранилище (например, карта памяти)
-        недоступно.
-    </string>
     <string name="feed_search">Поиск лент</string>
 	<string name="feed_search_hint">Введите ссылку или ключевое слово</string>
     <string name="feed_added">Лента добавлена в список</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -49,7 +49,6 @@
     <string name="menu_export">Export do OPML</string>
     <string name="storage_request_explanation">To be able to import or export the feeds from or to a file, you must allow the application to access to the storage memory.</string>
     <string name="error_feed_export">Export zlyhal. Na pripojenú SD kartu sa pravdepodobne nedá zapisovať.</string>
-    <string name="error_external_storage_not_available">Externý úložný priestor (napr. SD karta) nie je dostupný.</string>
     <string name="feed_search">Prehľadať zdroj</string>
 	<string name="feed_search_hint">Enter feed link or keyword</string>
     <string name="feed_added">Feed added to the list</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -27,7 +27,6 @@
     <string name="menu_export">Извези у ОПМЛ</string>
     <string name="storage_request_explanation">Да би увоз/извоз довода био могућ у или из датотеке, неопходно је да дозволите апликацији приступ интерном складишту.</string>
     <string name="error_feed_export">Извоз није завршен успешно. Проверите да ли уређај има СД картицу монтирану у систему.</string>
-    <string name="error_external_storage_not_available">Спољна меморија (СД картица) није доступна.</string>
     <string name="feed_search">Претрага довода</string>
     <string name="feed_search_hint">Унесите везу до довода или кључну реч</string>
     <string name="feed_added">Довод је додат у листу</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -47,7 +47,6 @@
     <string name="menu_export">Exportera till OPML</string>
     <string name="storage_request_explanation">För att kunna importera eller exportera en fil, du måste ge appen behörighet att läsa och spara på minneskort.</string>
     <string name="error_feed_export">Exporten har misslyckats. Försäkra dig om att du har ett skrivbart SD-kort monterat.</string>
-    <string name="error_external_storage_not_available">Det externa lagringsmediet (d.v.s. SD-kort) finns ej tillgängligt.</string>
     <string name="feed_search">Sök efter feed</string>
 	<string name="feed_search_hint">Enter feed link or keyword</string>
     <string name="feed_added">Feed added to the list</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -47,7 +47,6 @@
     <string name="menu_export">导出为OPML</string>
     <string name="storage_request_explanation">程序需要获取存储读写权限以便导入导出订阅源。</string>
     <string name="error_feed_export">导出失败，请确定你的SD卡可以读写。</string>
-    <string name="error_external_storage_not_available">外置存储（如SD卡）不可用。</string>
     <string name="feed_search">搜索订阅</string>
 	<string name="feed_search_hint">Enter feed link or keyword</string>
     <string name="feed_added">Feed added to the list</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,7 +27,6 @@
     <string name="menu_export">Export to OPML</string>
     <string name="storage_request_explanation">To be able to import or export the feeds from or to a file, you must allow the application to access to the storage memory.</string>
     <string name="error_feed_export">The export has failed. Make sure you have a writable SD-card mounted.</string>
-    <string name="error_external_storage_not_available">The external storage (e.g. SD-card) is not available.</string>
     <string name="feed_search">Feed search</string>
     <string name="feed_search_hint">Enter feed link or keyword</string>
     <string name="feed_added">Feed added to the list</string>


### PR DESCRIPTION
Add support for Android's buildin storage access framework on opml im/export. So a user can choose the folder of export and has the ability to use different storage providers like GDrive or Nextcloud. 