### PR TITLE
fix trigger interferences on display priority update

### DIFF
--- a/app/schemas/net.frju.flym.data.AppDatabase/3.json
+++ b/app/schemas/net.frju.flym.data.AppDatabase/3.json
@@ -1,0 +1,286 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "31435aa9bc89d78889a9d396fa842371",
+    "entities": [
+      {
+        "tableName": "feeds",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`feedId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `feedLink` TEXT NOT NULL, `feedTitle` TEXT, `feedImageLink` TEXT, `fetchError` INTEGER NOT NULL, `retrieveFullText` INTEGER NOT NULL, `isGroup` INTEGER NOT NULL, `groupId` INTEGER, `displayPriority` INTEGER NOT NULL, `lastManualActionUid` TEXT NOT NULL, FOREIGN KEY(`groupId`) REFERENCES `feeds`(`feedId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "feedId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "link",
+            "columnName": "feedLink",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "feedTitle",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageLink",
+            "columnName": "feedImageLink",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fetchError",
+            "columnName": "fetchError",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "retrieveFullText",
+            "columnName": "retrieveFullText",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isGroup",
+            "columnName": "isGroup",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "displayPriority",
+            "columnName": "displayPriority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastManualActionUid",
+            "columnName": "lastManualActionUid",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "feedId"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_feeds_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "createSql": "CREATE  INDEX `index_feeds_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          },
+          {
+            "name": "index_feeds_feedId_feedLink",
+            "unique": true,
+            "columnNames": [
+              "feedId",
+              "feedLink"
+            ],
+            "createSql": "CREATE UNIQUE INDEX `index_feeds_feedId_feedLink` ON `${TABLE_NAME}` (`feedId`, `feedLink`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "feeds",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "groupId"
+            ],
+            "referencedColumns": [
+              "feedId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `feedId` INTEGER NOT NULL, `link` TEXT, `fetchDate` INTEGER NOT NULL, `publicationDate` INTEGER NOT NULL, `title` TEXT, `description` TEXT, `mobilizedContent` TEXT, `imageLink` TEXT, `author` TEXT, `read` INTEGER NOT NULL, `favorite` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`feedId`) REFERENCES `feeds`(`feedId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedId",
+            "columnName": "feedId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "link",
+            "columnName": "link",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fetchDate",
+            "columnName": "fetchDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publicationDate",
+            "columnName": "publicationDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mobilizedContent",
+            "columnName": "mobilizedContent",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageLink",
+            "columnName": "imageLink",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "read",
+            "columnName": "read",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favorite",
+            "columnName": "favorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_entries_feedId",
+            "unique": false,
+            "columnNames": [
+              "feedId"
+            ],
+            "createSql": "CREATE  INDEX `index_entries_feedId` ON `${TABLE_NAME}` (`feedId`)"
+          },
+          {
+            "name": "index_entries_link",
+            "unique": true,
+            "columnNames": [
+              "link"
+            ],
+            "createSql": "CREATE UNIQUE INDEX `index_entries_link` ON `${TABLE_NAME}` (`link`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "feeds",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "feedId"
+            ],
+            "referencedColumns": [
+              "feedId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "tasks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`entryId` TEXT NOT NULL, `imageLinkToDl` TEXT NOT NULL, `numberAttempt` INTEGER NOT NULL, PRIMARY KEY(`entryId`, `imageLinkToDl`), FOREIGN KEY(`entryId`) REFERENCES `entries`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "entryId",
+            "columnName": "entryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageLinkToDl",
+            "columnName": "imageLinkToDl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numberAttempt",
+            "columnName": "numberAttempt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "entryId",
+            "imageLinkToDl"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_tasks_entryId",
+            "unique": false,
+            "columnNames": [
+              "entryId"
+            ],
+            "createSql": "CREATE  INDEX `index_tasks_entryId` ON `${TABLE_NAME}` (`entryId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "entries",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "entryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"31435aa9bc89d78889a9d396fa842371\")"
+    ]
+  }
+}

--- a/app/src/main/java/net/frju/flym/data/AppDatabase.kt
+++ b/app/src/main/java/net/frju/flym/data/AppDatabase.kt
@@ -34,7 +34,7 @@ import net.frju.flym.data.entities.Task
 import org.jetbrains.anko.doAsync
 
 
-@Database(entities = [Feed::class, Entry::class, Task::class], version = 2)
+@Database(entities = [Feed::class, Entry::class, Task::class], version = 3)
 @TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
 
@@ -48,9 +48,29 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_2_3: Migration = object : Migration(2, 3) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("DROP TRIGGER feed_update_decrease_priority")
+                database.execSQL("DROP TRIGGER feed_update_increase_priority")
+                database.execSQL("DROP TRIGGER feed_update_decrease_priority_same_group")
+                database.execSQL("DROP TRIGGER feed_update_increase_priority_same_group")
+                database.execSQL("""
+                                CREATE TRIGGER feed_update_priority_group
+                                    AFTER UPDATE
+                                    ON feeds
+                                    WHEN NOT(OLD.groupId IS NEW.groupId) OR NEW.displayPriority != OLD.displayPriority
+                                BEGIN
+                                    UPDATE feeds SET displayPriority = (SELECT COUNT() FROM feeds f JOIN feeds fl ON fl.displayPriority <= f.displayPriority AND fl.groupId IS f.groupId WHERE f.feedId = feeds.feedId GROUP BY f.feedId) WHERE feedId != NEW.feedId;
+                                    UPDATE feeds SET displayPriority = (SELECT COUNT() + 1 FROM feeds f WHERE f.displayPriority < NEW.displayPriority AND f.groupId IS NEW.groupId ) WHERE feedId = NEW.feedId;
+                                END;
+                                """.trimIndent())
+            }
+        }
+
         fun createDatabase(context: Context): AppDatabase {
             return Room.databaseBuilder(context.applicationContext, AppDatabase::class.java, DATABASE_NAME)
                     .addMigrations(MIGRATION_1_2)
+                    .addMigrations(MIGRATION_2_3)
                     .addCallback(object : Callback() {
                         override fun onCreate(db: SupportSQLiteDatabase) {
                             super.onCreate(db)
@@ -66,47 +86,15 @@ abstract class AppDatabase : RoomDatabase() {
                                 END;
                                 """.trimIndent())
 
-                                // groupId changed => decrease priority of feeds from old group
+                                // update priority of some group's feeds
                                 db.execSQL("""
-                                CREATE TRIGGER feed_update_decrease_priority
-                                    BEFORE UPDATE OF lastManualActionUid
+                                CREATE TRIGGER feed_update_priority_group
+                                    AFTER UPDATE
                                     ON feeds
-                                    WHEN OLD.groupId IS NOT NEW.groupId
+                                    WHEN NOT(OLD.groupId IS NEW.groupId) OR NEW.displayPriority != OLD.displayPriority
                                 BEGIN
-                                   UPDATE feeds SET displayPriority = displayPriority - 1 WHERE displayPriority > NEW.displayPriority AND groupId IS OLD.groupId AND feedId != NEW.feedId;
-                                END;
-                                """.trimIndent())
-
-                                // groupId changed => increase priority of feeds from new group
-                                db.execSQL("""
-                                CREATE TRIGGER feed_update_increase_priority
-                                    BEFORE UPDATE OF lastManualActionUid
-                                    ON feeds
-                                    WHEN OLD.groupId IS NOT NEW.groupId
-                                BEGIN
-                                   UPDATE feeds SET displayPriority = displayPriority + 1 WHERE displayPriority > NEW.displayPriority - 1 AND groupId IS NEW.groupId AND feedId != NEW.feedId;
-                                END;
-                                """.trimIndent())
-
-                                // same groupId => decrease priority of some group's feeds
-                                db.execSQL("""
-                                CREATE TRIGGER feed_update_decrease_priority_same_group
-                                    BEFORE UPDATE OF lastManualActionUid
-                                    ON feeds
-                                    WHEN OLD.groupId IS NEW.groupId AND NEW.displayPriority > OLD.displayPriority
-                                BEGIN
-                                   UPDATE feeds SET displayPriority = displayPriority - 1 WHERE (displayPriority BETWEEN OLD.displayPriority + 1 AND NEW.displayPriority) AND groupId IS OLD.groupId AND feedId != NEW.feedId;
-                                END;
-                                """.trimIndent())
-
-                                // same groupId => increase priority of some group's feeds
-                                db.execSQL("""
-                                CREATE TRIGGER feed_update_increase_priority_same_group
-                                    BEFORE UPDATE OF lastManualActionUid
-                                    ON feeds
-                                    WHEN OLD.groupId IS NEW.groupId AND NEW.displayPriority < OLD.displayPriority
-                                BEGIN
-                                   UPDATE feeds SET displayPriority = displayPriority + 1 WHERE (displayPriority BETWEEN NEW.displayPriority AND OLD.displayPriority - 1) AND groupId IS OLD.groupId AND feedId != NEW.feedId;
+                                    UPDATE feeds SET displayPriority = (SELECT COUNT() FROM feeds f JOIN feeds fl ON fl.displayPriority <= f.displayPriority AND fl.groupId IS f.groupId WHERE f.feedId = feeds.feedId GROUP BY f.feedId) WHERE feedId != NEW.feedId;
+                                    UPDATE feeds SET displayPriority = (SELECT COUNT() + 1 FROM feeds f WHERE f.displayPriority < NEW.displayPriority AND f.groupId IS NEW.groupId ) WHERE feedId = NEW.feedId;
                                 END;
                                 """.trimIndent())
                             }


### PR DESCRIPTION
Currently feed sorting is accomplished by four sql triggers. Unfortunately they are called in a cascade order (inccrease on one item may cause decrease trigger called on other items - so you get wild reordering sometimes and corrupt displayPriority fields). To solve this I tried to put this functionality in a single sql trigger.