### PR TITLE
Add Black Theme

### DIFF
--- a/app/src/main/java/net/frju/flym/data/utils/PrefConstants.kt
+++ b/app/src/main/java/net/frju/flym/data/utils/PrefConstants.kt
@@ -28,7 +28,7 @@ object PrefConstants {
     const val REFRESH_INTERVAL = "refresh_interval"
     const val REFRESH_WIFI_ONLY = "refresh_wifi_only"
 
-    const val DARK_THEME = "dark_theme"
+    const val THEME = "theme"
     const val DISPLAY_IMAGES = "display_images"
 
     const val PRELOAD_IMAGE_MODE = "preload_image_mode"

--- a/app/src/main/java/net/frju/flym/ui/about/AboutActivity.kt
+++ b/app/src/main/java/net/frju/flym/ui/about/AboutActivity.kt
@@ -23,14 +23,19 @@ import android.view.MenuItem
 import com.vansuita.materialabout.builder.AboutBuilder
 import net.fred.feedex.R
 import net.frju.flym.data.utils.PrefConstants
-import net.frju.flym.utils.getPrefBoolean
+import net.frju.flym.utils.getPrefString
 
 
 class AboutActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         //Choose theme
-        setTheme(if (getPrefBoolean(PrefConstants.DARK_THEME, true)) R.style.AppTheme else R.style.AppThemeLight)
+        setTheme(when (getPrefString(PrefConstants.THEME, "DARK")) {
+            "LIGHT" -> R.style.AppThemeLight
+            "DARK" -> R.style.AppTheme
+            "BLACK" -> R.style.AppThemeBlack
+            else -> R.style.AppTheme
+        })
 
         super.onCreate(savedInstanceState)
 

--- a/app/src/main/java/net/frju/flym/ui/entrydetails/EntryDetailsActivity.kt
+++ b/app/src/main/java/net/frju/flym/ui/entrydetails/EntryDetailsActivity.kt
@@ -18,20 +18,25 @@
 package net.frju.flym.ui.entrydetails
 
 import android.os.Bundle
+import android.support.design.widget.AppBarLayout
 import android.support.v7.app.AppCompatActivity
 import android.view.MenuItem
 import net.fred.feedex.R
 import net.frju.flym.data.utils.PrefConstants
-import net.frju.flym.utils.getPrefBoolean
+import net.frju.flym.utils.getPrefString
 
 class EntryDetailsActivity : AppCompatActivity() {
 
 	override fun onCreate(savedInstanceState: Bundle?) {
         //Choose theme
-		setTheme(if (getPrefBoolean(PrefConstants.DARK_THEME, true)) R.style.AppTheme_NoActionBar else R.style.AppThemeLight_NoActionBar)
+		setTheme(when (getPrefString(PrefConstants.THEME, "DARK")) {
+			"LIGHT" -> R.style.AppThemeLight_NoActionBar
+			"DARK" -> R.style.AppTheme_NoActionBar
+			"BLACK" -> R.style.AppThemeBlack_NoActionBar
+			else -> R.style.AppTheme_NoActionBar
+		})
 
         super.onCreate(savedInstanceState)
-
 
 		if (savedInstanceState == null) {
 			val fragment = EntryDetailsFragment().apply {

--- a/app/src/main/java/net/frju/flym/ui/feeds/BaseFeedAdapter.kt
+++ b/app/src/main/java/net/frju/flym/ui/feeds/BaseFeedAdapter.kt
@@ -30,6 +30,7 @@ import net.frju.flym.data.entities.Feed
 import net.frju.flym.data.entities.FeedWithCount
 import net.frju.flym.data.utils.PrefConstants
 import net.frju.flym.utils.getPrefBoolean
+import net.frju.flym.utils.getPrefString
 import org.jetbrains.anko.dip
 import org.jetbrains.anko.sdk21.listeners.onClick
 import org.jetbrains.anko.sdk21.listeners.onLongClick
@@ -106,25 +107,33 @@ abstract class BaseFeedAdapter(groups: List<FeedGroup>) : ExpandableRecyclerAdap
 			if (group.feedWithCount.feed.isGroup) {
 				if (isExpanded) {
 					itemView.icon.setImageResource(
-                            if (itemView.context.getPrefBoolean(PrefConstants.DARK_THEME, true)) R.drawable.ic_keyboard_arrow_up_white_24dp else R.drawable.ic_keyboard_arrow_up_black_24dp
-					)
+							when (itemView.context.getPrefString(PrefConstants.THEME, "DARK")) {
+								"LIGHT" -> R.drawable.ic_keyboard_arrow_up_black_24dp
+								else -> R.drawable.ic_keyboard_arrow_up_white_24dp
+							})
 				} else {
 					itemView.icon.setImageResource(
-                            if (itemView.context.getPrefBoolean(PrefConstants.DARK_THEME, true)) R.drawable.ic_keyboard_arrow_down_white_24dp else R.drawable.ic_keyboard_arrow_down_black_24dp
-					)
+							when (itemView.context.getPrefString(PrefConstants.THEME, "DARK")) {
+								"LIGHT" -> R.drawable.ic_keyboard_arrow_down_black_24dp
+								else -> R.drawable.ic_keyboard_arrow_down_white_24dp
+							})
 				}
 
 				itemView.icon.isClickable = true
 				itemView.icon.onClick {
 					if (isExpanded) {
 						itemView.icon.setImageResource(
-                                if (itemView.context.getPrefBoolean(PrefConstants.DARK_THEME, true)) R.drawable.ic_keyboard_arrow_down_white_24dp else R.drawable.ic_keyboard_arrow_down_black_24dp
-						)
+								when (itemView.context.getPrefString(PrefConstants.THEME, "DARK")) {
+									"LIGHT" -> R.drawable.ic_keyboard_arrow_down_black_24dp
+									else -> R.drawable.ic_keyboard_arrow_down_white_24dp
+								})
 						collapseView()
 					} else {
 						itemView.icon.setImageResource(
-                                if (itemView.context.getPrefBoolean(PrefConstants.DARK_THEME, true)) R.drawable.ic_keyboard_arrow_up_white_24dp else R.drawable.ic_keyboard_arrow_up_black_24dp
-						)
+								when (itemView.context.getPrefString(PrefConstants.THEME, "DARK")) {
+									"LIGHT" -> R.drawable.ic_keyboard_arrow_up_black_24dp
+									else -> R.drawable.ic_keyboard_arrow_up_white_24dp
+								})
 						expandView()
 					}
 				}
@@ -132,8 +141,10 @@ abstract class BaseFeedAdapter(groups: List<FeedGroup>) : ExpandableRecyclerAdap
 				itemView.icon.isClickable = false
 				if (group.feedWithCount.feed.id == Feed.ALL_ENTRIES_ID) {
 					itemView.icon.setImageResource(
-                            if (itemView.context.getPrefBoolean(PrefConstants.DARK_THEME, true)) R.drawable.ic_list_white_24dp else R.drawable.ic_list_black_24dp
-					)
+							when (itemView.context.getPrefString(PrefConstants.THEME, "DARK")) {
+								"LIGHT" -> R.drawable.ic_list_black_24dp
+								else -> R.drawable.ic_list_white_24dp
+							})
 				} else {
 					itemView.icon.setImageDrawable(group.feedWithCount.feed.getLetterDrawable(true))
 				}
@@ -143,7 +154,11 @@ abstract class BaseFeedAdapter(groups: List<FeedGroup>) : ExpandableRecyclerAdap
             if (group.feedWithCount.feed.fetchError || group.subFeeds.any { it.feed.fetchError }) {
                 itemView.title.setTextColor(Color.RED) //TODO better
 			} else {
-                itemView.title.setTextColor(if (itemView.context.getPrefBoolean(PrefConstants.DARK_THEME, true)) Color.WHITE else Color.BLACK)
+                itemView.title.setTextColor(
+						when (itemView.context.getPrefString(PrefConstants.THEME, "DARK")) {
+							"LIGHT" -> Color.BLACK
+							else -> Color.WHITE
+						})
 			}
 			itemView.setPadding(0, 0, 0, 0)
 			itemView.onClick {
@@ -168,7 +183,11 @@ abstract class BaseFeedAdapter(groups: List<FeedGroup>) : ExpandableRecyclerAdap
 			if (feedWithCount.feed.fetchError) { //TODO better
 				itemView.title.setTextColor(Color.RED)
 			} else {
-                itemView.title.setTextColor(if (itemView.context.getPrefBoolean(PrefConstants.DARK_THEME, true)) Color.WHITE else Color.BLACK)
+                itemView.title.setTextColor(
+						when (itemView.context.getPrefString(PrefConstants.THEME, "DARK")) {
+							"LIGHT" -> Color.BLACK
+							else -> Color.WHITE
+						})
 			}
 			itemView.icon.isClickable = false
 			itemView.icon.setImageDrawable(feedWithCount.feed.getLetterDrawable(true))

--- a/app/src/main/java/net/frju/flym/ui/feeds/FeedListEditActivity.kt
+++ b/app/src/main/java/net/frju/flym/ui/feeds/FeedListEditActivity.kt
@@ -22,13 +22,18 @@ import android.support.v7.app.AppCompatActivity
 import android.view.MenuItem
 import net.fred.feedex.R
 import net.frju.flym.data.utils.PrefConstants
-import net.frju.flym.utils.getPrefBoolean
+import net.frju.flym.utils.getPrefString
 
 class FeedListEditActivity : AppCompatActivity() {
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		//Choose theme
-		setTheme(if (getPrefBoolean(PrefConstants.DARK_THEME, true)) R.style.AppTheme else R.style.AppThemeLight)
+		setTheme(when (getPrefString(PrefConstants.THEME, "DARK")) {
+			"LIGHT" -> R.style.AppThemeLight
+			"DARK" -> R.style.AppTheme
+			"BLACK" -> R.style.AppThemeBlack
+			else -> R.style.AppTheme
+		})
 
 		super.onCreate(savedInstanceState)
 

--- a/app/src/main/java/net/frju/flym/ui/main/MainActivity.kt
+++ b/app/src/main/java/net/frju/flym/ui/main/MainActivity.kt
@@ -63,6 +63,7 @@ import net.frju.flym.ui.feeds.FeedListEditActivity
 import net.frju.flym.ui.settings.SettingsActivity
 import net.frju.flym.utils.closeKeyboard
 import net.frju.flym.utils.getPrefBoolean
+import net.frju.flym.utils.getPrefString
 import net.frju.flym.utils.putPrefBoolean
 import org.jetbrains.anko.*
 import org.jetbrains.anko.sdk21.listeners.onClick
@@ -98,7 +99,12 @@ class MainActivity : AppCompatActivity(), MainNavigator, AnkoLogger {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         //Choose theme
-        setTheme(if (getPrefBoolean(PrefConstants.DARK_THEME, true)) R.style.AppTheme_NoActionBar else R.style.AppThemeLight_NoActionBar)
+        setTheme(when (getPrefString(PrefConstants.THEME, "DARK")) {
+            "LIGHT" -> R.style.AppThemeLight_NoActionBar
+            "DARK" -> R.style.AppTheme_NoActionBar
+            "BLACK" -> R.style.AppThemeBlack_NoActionBar
+            else -> R.style.AppTheme_NoActionBar
+        })
 
         super.onCreate(savedInstanceState)
 

--- a/app/src/main/java/net/frju/flym/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/net/frju/flym/ui/settings/SettingsActivity.kt
@@ -21,15 +21,19 @@ import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.view.MenuItem
 import net.fred.feedex.R
-import net.frju.flym.App.Companion.context
 import net.frju.flym.data.utils.PrefConstants
-import net.frju.flym.utils.getPrefBoolean
+import net.frju.flym.utils.getPrefString
 
 class SettingsActivity : AppCompatActivity() {
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		//Choose theme
-        setTheme(if (context.getPrefBoolean(PrefConstants.DARK_THEME, true)) R.style.AppTheme else R.style.AppThemeLight)
+		setTheme(when (getPrefString(PrefConstants.THEME, "DARK")) {
+			"LIGHT" -> R.style.AppThemeLight
+			"DARK" -> R.style.AppTheme
+			"BLACK" -> R.style.AppThemeBlack
+			else -> R.style.AppTheme
+		})
 
 		super.onCreate(savedInstanceState)
 

--- a/app/src/main/java/net/frju/flym/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/net/frju/flym/ui/settings/SettingsFragment.kt
@@ -42,9 +42,9 @@ class SettingsFragment : PreferenceFragment() {
 		findPreference(PrefConstants.REFRESH_ENABLED)?.onPreferenceChangeListener = onRefreshChangeListener
 		findPreference(PrefConstants.REFRESH_INTERVAL)?.onPreferenceChangeListener = onRefreshChangeListener
 
-		findPreference(PrefConstants.DARK_THEME)?.setOnPreferenceChangeListener { preference, any ->
+		findPreference(PrefConstants.THEME)?.setOnPreferenceChangeListener { preference, any ->
 			activity.finishAffinity()
-            startActivity<MainActivity>()
+			startActivity<MainActivity>()
 			true
 		}
 	}

--- a/app/src/main/res/color/colored_read_state_black.xml
+++ b/app/src/main/res/color/colored_read_state_black.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:color="@color/color_read_black" />
+    <item android:color="@color/color_unread_black" />
+</selector>

--- a/app/src/main/res/color/read_state_black.xml
+++ b/app/src/main/res/color/read_state_black.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:color="@color/color_read_black" />
+    <item android:color="@color/color_unread_black" />
+</selector>

--- a/app/src/main/res/layout/fragment_entry_details.xml
+++ b/app/src/main/res/layout/fragment_entry_details.xml
@@ -6,13 +6,13 @@
     <android.support.design.widget.AppBarLayout
         android:id="@+id/app_bar_layout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:theme="@style/AppTheme.ActionBar.Details">
+        android:layout_height="wrap_content">
 
         <android.support.v7.widget.Toolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
-            android:layout_height="?android:attr/actionBarSize" />
+            android:layout_height="?android:attr/actionBarSize"
+            android:theme="@style/AppTheme.ActionBar.Details"/>
 
     </android.support.design.widget.AppBarLayout>
 

--- a/app/src/main/res/layout/view_main_containers.xml
+++ b/app/src/main/res/layout/view_main_containers.xml
@@ -14,14 +14,13 @@
             android:fitsSystemWindows="true"
             android:stateListAnimator="@animator/appbar_always_elevated"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:theme="@style/AppTheme.ActionBar">
+            android:layout_height="wrap_content">
 
             <android.support.v7.widget.Toolbar
 				android:id="@+id/toolbar"
 				android:layout_width="match_parent"
 				android:layout_height="?android:attr/actionBarSize"
-				app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+                android:theme="@style/AppTheme.ActionBar.Details"/>
         </android.support.design.widget.AppBarLayout>
 
         <FrameLayout

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -83,8 +83,7 @@
     <string name="settings_remove_duplicates_description_title">Remove duplicates</string>
     <string name="settings_remove_duplicates_description">Checks the title of newly downloaded item and skips when one with the same title is already present</string>
     <string name="filter">Remove items containing keywords (coma-separated list)</string>
-    <string name="settings_dark_theme">Enable dark theme</string>
-    <string name="settings_dark_theme_description">Change the interface colors for better comfort in low light environements</string>
+    <string name="settings_theme">Theme</string>
 
     <plurals name="number_of_new_entries">
         <item quantity="one">Jedan novi članak</item>
@@ -124,5 +123,10 @@
         <item>Nikada</item>
         <item>Samo preko bežične mreže (Wi-Fi)</item>
         <item>Uvek</item>
+    </string-array>
+    <string-array name="settings_themes">
+        <item>Light</item>
+        <item>Dark</item>
+        <item>Black</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -91,8 +91,7 @@
     <string name="settings_remove_duplicates_description_title">Remove duplicates</string>
     <string name="settings_remove_duplicates_description">Checks the title of newly downloaded item and skips when one with the same title is already present</string>
     <string name="filter">Remove items containing keywords (coma-separated list)</string>
-    <string name="settings_dark_theme">Enable dark theme</string>
-    <string name="settings_dark_theme_description">Change the interface colors for better comfort in low light environements</string>
+    <string name="settings_theme">Theme</string>
 
     <plurals name="number_of_new_entries">
         <item quantity="one">Una entrada nova</item>
@@ -132,6 +131,11 @@
         <item>Mai</item>
         <item>Només amb Wi-Fi</item>
         <item>Sempre</item>
+    </string-array>
+    <string-array name="settings_themes">
+        <item>Light</item>
+        <item>Dark</item>
+        <item>Black</item>
     </string-array>
 
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -113,8 +113,7 @@
     <string name="settings_remove_duplicates_description_title">Remove duplicates</string>
     <string name="settings_remove_duplicates_description">Checks the title of newly downloaded item and skips when one with the same title is already present</string>
     <string name="filter">Remove items containing keywords (coma-separated list)</string>
-    <string name="settings_dark_theme">Enable dark theme</string>
-    <string name="settings_dark_theme_description">Change the interface colors for better comfort in low light environements</string>
+    <string name="settings_theme">Theme</string>
 
     <plurals name="number_of_new_entries">
         <item quantity="one">Jeden nový článek</item>
@@ -155,6 +154,11 @@
         <item>Nikdy</item>
         <item>Pouze přes Wi-Fi</item>
         <item>Vždy</item>
+    </string-array>
+    <string-array name="settings_themes">
+        <item>Light</item>
+        <item>Dark</item>
+        <item>Black</item>
     </string-array>
 
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -106,8 +106,7 @@
     <string name="settings_remove_duplicates_description_title">Duplikate entfernen</string>
     <string name="settings_remove_duplicates_description">Untersucht Titel von neu heruntergeladenen Einträgen. Überspringt, wenn ein Eintrag mit demselben Titel bereits vorhanden ist</string>
     <string name="filter">Einträge, welche nachfolgende Schlüsselworte beinhalten, entfernen (kommaseparierte Liste)</string>
-    <string name="settings_dark_theme">Dunkles Thema aktivieren</string>
-    <string name="settings_dark_theme_description">Verändert die Farben der Oberfläche, um ein besseres Erlebnis bei gedimmten Umgebungen zu erreichen</string>
+    <string name="settings_theme">Thema</string>
 
     <plurals name="number_of_new_entries">
         <item quantity="one">Ein neuer Eintrag</item>
@@ -147,6 +146,11 @@
         <item>Niemals</item>
         <item>Nur über WLAN</item>
         <item>Immer</item>
+    </string-array>
+    <string-array name="settings_themes">
+        <item>Light</item>
+        <item>Dunkles</item>
+        <item>Black</item>
     </string-array>
 
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -111,8 +111,7 @@
     <string name="settings_remove_duplicates_description_title">Remove duplicates</string>
     <string name="settings_remove_duplicates_description">Checks the title of newly downloaded item and skips when one with the same title is already present</string>
     <string name="filter">Remove items containing keywords (coma-separated list)</string>
-    <string name="settings_dark_theme">Enable dark theme</string>
-    <string name="settings_dark_theme_description">Change the interface colors for better comfort in low light environements</string>
+    <string name="settings_theme">Theme</string>
 
     <plurals name="number_of_new_entries">
         <item quantity="one">One new entry</item>
@@ -152,6 +151,11 @@
         <item>Never</item>
         <item>Only over Wi-Fi</item>
         <item>Always</item>
+    </string-array>
+    <string-array name="settings_themes">
+        <item>Light</item>
+        <item>Dark</item>
+        <item>Black</item>
     </string-array>
 
 </resources>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -112,8 +112,7 @@
     <string name="settings_remove_duplicates_description_title">Remove duplicates</string>
     <string name="settings_remove_duplicates_description">Checks the title of newly downloaded item and skips when one with the same title is already present</string>
     <string name="filter">Remove items containing keywords (coma-separated list)</string>
-    <string name="settings_dark_theme">Enable dark theme</string>
-    <string name="settings_dark_theme_description">Change the interface colors for better comfort in low light environements</string>
+    <string name="settings_theme">Theme</string>
 
     <plurals name="number_of_new_entries">
         <item quantity="one">Sarrera berri bat</item>
@@ -153,6 +152,11 @@
         <item>Inoiz</item>
         <item>Wi-Fipean soilik</item>
         <item>Beti</item>
+    </string-array>
+    <string-array name="settings_themes">
+        <item>Light</item>
+        <item>Dark</item>
+        <item>Black</item>
     </string-array>
 
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -108,8 +108,7 @@
     <string name="settings_remove_duplicates_description_title">Remove duplicates</string>
     <string name="settings_remove_duplicates_description">Checks the title of newly downloaded item and skips when one with the same title is already present</string>
     <string name="filter">Remove items containing keywords (coma-separated list)</string>
-    <string name="settings_dark_theme">Enable dark theme</string>
-    <string name="settings_dark_theme_description">Change the interface colors for better comfort in low light environements</string>
+    <string name="settings_theme">Theme</string>
 
     <plurals name="number_of_new_entries">
         <item quantity="one">Yksi uusi artikkeli</item>
@@ -149,6 +148,11 @@
         <item>Ei koskaan</item>
         <item>Vain Wi-Fi -yhteyden kautta</item>
         <item>Aina</item>
+    </string-array>
+    <string-array name="settings_themes">
+        <item>Light</item>
+        <item>Dark</item>
+        <item>Black</item>
     </string-array>
 
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -104,8 +104,7 @@
     <string name="settings_remove_duplicates_description_title">Supprimer les doublons</string>
     <string name="settings_remove_duplicates_description">Supprime les articles ayant le même titre que ceux déjà chargés</string>
     <string name="filter">Filtre les articles contenant des mots-clés (séparés par des virgules)</string>
-    <string name="settings_dark_theme">Activer thème sombre</string>
-    <string name="settings_dark_theme_description">Change les couleurs de l\'interface pour un meilleur confort dans les environnements sous-éclairés</string>
+    <string name="settings_theme">Theme</string>
 
     <plurals name="number_of_new_entries">
         <item quantity="one">%d nouvel article</item>
@@ -145,6 +144,11 @@
         <item>Jamais</item>
         <item>En Wi-Fi uniquement</item>
         <item>Toujours</item>
+    </string-array>
+    <string-array name="settings_themes">
+        <item>Clair</item>
+        <item>Sombre</item>
+        <item>Noir</item>
     </string-array>
 
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -104,8 +104,7 @@
     <string name="settings_remove_duplicates_description_title">Remove duplicates</string>
     <string name="settings_remove_duplicates_description">Checks the title of newly downloaded item and skips when one with the same title is already present</string>
     <string name="filter">Remove items containing keywords (coma-separated list)</string>
-    <string name="settings_dark_theme">Enable dark theme</string>
-    <string name="settings_dark_theme_description">Change the interface colors for better comfort in low light environements</string>
+    <string name="settings_theme">Theme</string>
 
     <plurals name="number_of_new_entries">
         <item quantity="one">Un nuovo articolo</item>
@@ -145,6 +144,11 @@
         <item>Mai</item>
         <item>Solo con Wi-Fi</item>
         <item>Sempre</item>
+    </string-array>
+    <string-array name="settings_themes">
+        <item>Light</item>
+        <item>Dark</item>
+        <item>Black</item>
     </string-array>
 
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -104,8 +104,7 @@
     <string name="settings_remove_duplicates_description_title">Remove duplicates</string>
     <string name="settings_remove_duplicates_description">Checks the title of newly downloaded item and skips when one with the same title is already present</string>
     <string name="filter">Remove items containing keywords (coma-separated list)</string>
-    <string name="settings_dark_theme">Enable dark theme</string>
-    <string name="settings_dark_theme_description">Change the interface colors for better comfort in low light environements</string>
+    <string name="settings_theme">Theme</string>
 
     <plurals name="number_of_new_entries">
         <item quantity="other">새 항목 %d개</item>
@@ -144,6 +143,11 @@
         <item>안 함</item>
         <item>Wi-Fi를 통해서만</item>
         <item>언제나</item>
+    </string-array>
+    <string-array name="settings_themes">
+        <item>Light</item>
+        <item>Dark</item>
+        <item>Black</item>
     </string-array>
 
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -83,8 +83,7 @@
     <string name="settings_remove_duplicates_description_title">Remove duplicates</string>
     <string name="settings_remove_duplicates_description">Checks the title of newly downloaded item and skips when one with the same title is already present</string>
     <string name="filter">Remove items containing keywords (coma-separated list)</string>
-    <string name="settings_dark_theme">Enable dark theme</string>
-    <string name="settings_dark_theme_description">Change the interface colors for better comfort in low light environements</string>
+    <string name="settings_theme">Theme</string>
 
     <plurals name="number_of_new_entries">
         <item quantity="one">Eén nieuw item</item>
@@ -124,5 +123,10 @@
         <item>Nooit</item>
         <item>Alleen via Wi-Fi</item>
         <item>Altijd</item>
+    </string-array>
+    <string-array name="settings_themes">
+        <item>Light</item>
+        <item>Dark</item>
+        <item>Black</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -103,8 +103,7 @@
     <string name="settings_remove_duplicates_description_title">Remove duplicates</string>
     <string name="settings_remove_duplicates_description">Checks the title of newly downloaded item and skips when one with the same title is already present</string>
     <string name="filter">Remove items containing keywords (coma-separated list)</string>
-    <string name="settings_dark_theme">Enable dark theme</string>
-    <string name="settings_dark_theme_description">Change the interface colors for better comfort in low light environements</string>
+    <string name="settings_theme">Theme</string>
 
     <plurals name="number_of_new_entries">
         <item quantity="one">Uma nova entrada</item>
@@ -144,6 +143,11 @@
         <item>Nunca</item>
         <item>Apenas com Wi-Fi</item>
         <item>Sempre</item>
+    </string-array>
+    <string-array name="settings_themes">
+        <item>Light</item>
+        <item>Dark</item>
+        <item>Black</item>
     </string-array>
 
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -113,8 +113,7 @@
     <string name="settings_remove_duplicates_description_title">Remove duplicates</string>
     <string name="settings_remove_duplicates_description">Checks the title of newly downloaded item and skips when one with the same title is already present</string>
     <string name="filter">Remove items containing keywords (coma-separated list)</string>
-    <string name="settings_dark_theme">Enable dark theme</string>
-    <string name="settings_dark_theme_description">Change the interface colors for better comfort in low light environements</string>
+    <string name="settings_theme">Theme</string>
 
     <plurals name="number_of_new_entries">
         <item quantity="one">%d новая запись</item>
@@ -156,6 +155,11 @@
         <item>Никогда</item>
         <item>Только по Wi-Fi</item>
         <item>Всегда</item>
+    </string-array>
+    <string-array name="settings_themes">
+        <item>Light</item>
+        <item>Dark</item>
+        <item>Black</item>
     </string-array>
 
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -105,8 +105,7 @@
     <string name="settings_remove_duplicates_description_title">Remove duplicates</string>
     <string name="settings_remove_duplicates_description">Checks the title of newly downloaded item and skips when one with the same title is already present</string>
     <string name="filter">Remove items containing keywords (coma-separated list)</string>
-    <string name="settings_dark_theme">Enable dark theme</string>
-    <string name="settings_dark_theme_description">Change the interface colors for better comfort in low light environements</string>
+    <string name="settings_theme">Theme</string>
 
     <plurals name="number_of_new_entries">
         <item quantity="one">Jeden nový článok</item>
@@ -150,6 +149,11 @@
         <item>Nikdy</item>
         <item>Len cez Wi-Fi</item>
         <item>Vždy</item>
+    </string-array>
+    <string-array name="settings_themes">
+        <item>Light</item>
+        <item>Dark</item>
+        <item>Black</item>
     </string-array>
 
 </resources>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -83,8 +83,7 @@
     <string name="settings_remove_duplicates_description_title">Remove duplicates</string>
     <string name="settings_remove_duplicates_description">Checks the title of newly downloaded item and skips when one with the same title is already present</string>
     <string name="filter">Remove items containing keywords (coma-separated list)</string>
-    <string name="settings_dark_theme">Enable dark theme</string>
-    <string name="settings_dark_theme_description">Change the interface colors for better comfort in low light environements</string>
+    <string name="settings_theme">Theme</string>
 
     <plurals name="number_of_new_entries">
         <item quantity="one">Један нови чланак</item>
@@ -124,5 +123,10 @@
         <item>Никада</item>
         <item>Само преко бежичне мреже (Wi-Fi)</item>
         <item>Увек</item>
+    </string-array>
+    <string-array name="settings_themes">
+        <item>Light</item>
+        <item>Dark</item>
+        <item>Black</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -103,8 +103,7 @@
     <string name="settings_remove_duplicates_description_title">Remove duplicates</string>
     <string name="settings_remove_duplicates_description">Checks the title of newly downloaded item and skips when one with the same title is already present</string>
     <string name="filter">Remove items containing keywords (coma-separated list)</string>
-    <string name="settings_dark_theme">Enable dark theme</string>
-    <string name="settings_dark_theme_description">Change the interface colors for better comfort in low light environements</string>
+    <string name="settings_theme">Theme</string>
 
     <plurals name="number_of_new_entries">
         <item quantity="one">Ett nytt inlägg</item>
@@ -144,6 +143,11 @@
         <item>Aldrig</item>
         <item>Endast via Wi-Fi</item>
         <item>Alltid</item>
+    </string-array>
+    <string-array name="settings_themes">
+        <item>Light</item>
+        <item>Dark</item>
+        <item>Black</item>
     </string-array>
 
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -103,8 +103,7 @@
     <string name="settings_remove_duplicates_description_title">Remove duplicates</string>
     <string name="settings_remove_duplicates_description">Checks the title of newly downloaded item and skips when one with the same title is already present</string>
     <string name="filter">Remove items containing keywords (coma-separated list)</string>
-    <string name="settings_dark_theme">Enable dark theme</string>
-    <string name="settings_dark_theme_description">Change the interface colors for better comfort in low light environements</string>
+    <string name="settings_theme">Theme</string>
 
     <plurals name="number_of_new_entries">
         <item quantity="other">%d 条新消息</item>
@@ -143,6 +142,11 @@
         <item>从不</item>
         <item>仅限Wi-Fi</item>
         <item>总是</item>
+    </string-array>
+    <string-array name="settings_themes">
+        <item>Light</item>
+        <item>Dark</item>
+        <item>Black</item>
     </string-array>
 
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -29,4 +29,18 @@
     <color name="subtitle_light">#666666</color>
     <color name="subtitle_border_light">#ddd</color>
 
+    <!-- Black Theme specific colors -->
+    <color name="colorAccentBlack">#02C8B4</color>
+    <color name="colorPrimaryBlack">#111111</color>
+    <color name="colorPrimaryDarkBlack">#000000</color>
+    <color name="colorBackgroundBlack">#000000</color>
+    <color name="color_unread_black">#ffffff</color>
+    <color name="color_read_black">#9e9e9e</color>
+    <color name="bottom_navigation_disable_black">#7bffffff</color>
+    <color name="quote_background_black">#383b3f</color>
+    <color name="quote_left_black">#686b6f</color>
+    <color name="article_text_black">#C0C0C0</color>
+    <color name="subtitle_black">#8c8c8c</color>
+    <color name="subtitle_border_black">#303030</color>
+
 </resources>

--- a/app/src/main/res/values/not_translatable_strings.xml
+++ b/app/src/main/res/values/not_translatable_strings.xml
@@ -34,4 +34,9 @@
         <item>WIFI_ONLY_PRELOAD</item>
         <item>ALWAYS_PRELOAD</item>
     </string-array>
+    <string-array name="settings_themes_values">
+        <item>LIGHT</item>
+        <item>DARK</item>
+        <item>BLACK</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,7 @@
     <string name="filter">Remove items containing keywords (coma-separated list)</string>
     <string name="settings_dark_theme">Enable dark theme</string>
     <string name="settings_dark_theme_description">Change the interface colors for better comfort in low light environements</string>
+    <string name="settings_theme">Theme</string>
 
     <plurals name="number_of_new_entries">
         <item quantity="one">One new entry</item>
@@ -124,5 +125,10 @@
         <item>Never</item>
         <item>Only over Wi-Fi</item>
         <item>Always</item>
+    </string-array>
+    <string-array name="settings_themes">
+        <item>Light</item>
+        <item>Dark</item>
+        <item>Black</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -49,13 +49,46 @@
 
     <style name="AppThemeLight.ActionBar" parent="Theme.AppCompat.Light.DarkActionBar">
         <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryLight</item>
         <item name="colorAccent">@color/colorAccent</item>
     </style>
 
     <style name="AppThemeLight.ActionBar.Details" parent="AppThemeLight.ActionBar" />
 
     <style name="AppThemeLight.NoActionBar">
+
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+
+    <!-- Black theme -->
+    <style name="AppThemeBlack" parent="Theme.AppCompat">
+        <item name="colorPrimary">@color/colorPrimaryBlack</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDarkBlack</item>
+        <item name="colorAccent">@color/colorAccentBlack</item>
+        <item name="colorBackground">@color/colorBackgroundBlack</item>
+        <item name="android:windowBackground">@color/colorBackgroundBlack</item>
+        <item name="colorReadState">@color/read_state_black</item>
+        <item name="colorColoredReadState">@color/colored_read_state_black</item>
+        <item name="colorQuoteBackground">@color/quote_background_black</item>
+        <item name="colorQuoteLeft">@color/quote_left_black</item>
+        <item name="colorArticleText">@color/article_text_black</item>
+        <item name="colorSubtitle">@color/subtitle_black</item>
+        <item name="colorSubtitleBorder">@color/subtitle_border_black</item>
+
+    </style>
+
+    <style name="AppThemeBlack.ActionBar" parent="Theme.AppCompat">
+        <item name="colorPrimary">@color/colorPrimaryBlack</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDarkBlack</item>
+        <item name="colorAccent">@color/colorAccentBlack</item>
+        <item name="colorBackground">@color/colorBackgroundBlack</item>
+    </style>
+
+    <style name="AppThemeBlack.ActionBar.Details" parent="AppThemeBlack.ActionBar">
+    </style>
+
+    <style name="AppThemeBlack.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
     </style>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -41,12 +41,15 @@
         android:layout_height="wrap_content"
         android:title="@string/settings_category_content_presentation">
 
-        <CheckBoxPreference
-            android:id="@+id/dark_theme"
-            android:defaultValue="true"
-            android:key="dark_theme"
-            android:summary="@string/settings_dark_theme_description"
-            android:title="@string/settings_dark_theme" />
+        <net.frju.flym.ui.views.AutoSummaryListPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="DARK"
+            android:entries="@array/settings_themes"
+            android:entryValues="@array/settings_themes_values"
+            android:inputType="text"
+            android:key="theme"
+            android:title="@string/settings_theme" />
         <net.frju.flym.ui.views.AutoSummaryListPreference
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"


### PR DESCRIPTION
Adds a black theme optimized for Amoled screens. Issue #397 

The setTheme method before onCreate in all activities is ever worse now but I don't know a better way to do it.

All light-theme users will have to set their theme because I use a different preference :.