### PR TITLE
Fix German translation for "full text retrieval"

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -34,8 +34,8 @@
     <string name="menu_edit_feed">Feed bearbeiten</string>
     <string name="menu_reorder">Feeds neu ordnen</string>
     <string name="menu_delete">Löschen</string>
-    <string name="menu_enable_full_text_retrieval">Volltextsuche aktivieren</string>
-    <string name="menu_disable_full_text_retrieval">Volltextsuche deaktivieren</string>
+    <string name="menu_enable_full_text_retrieval">Ganzen Text abrufen</string>
+    <string name="menu_disable_full_text_retrieval">Nur Teaser abrufen</string>
     <string name="menu_all_read">Alle als gelesen markieren</string>
     <string name="flym_feeds">Flym-Feeds</string>
     <string name="error">Fehler</string>
@@ -51,7 +51,7 @@
     <string name="storage_request_explanation">Um Feeds aus/in eine(r) Datei zu importieren/exportieren, muss das Programm die Berechtigung haben auf den Speicher zuzugreifen.</string>
     <string name="error_feed_export">Der Export ist fehlgeschlagen. Stelle sicher, dass eine beschreibbare SD-Karte eingelegt ist.</string>
     <string name="feed_search">Feed-Suche</string>
-	<string name="feed_search_hint">Feed-Link oder Suchbegriff eingeben</string>
+    <string name="feed_search_hint">Feed-Link oder Suchbegriff eingeben</string>
     <string name="feed_added">Feed zur Liste hinzugefügt</string>
     <string name="question_delete_feed">Willst du diesen Feed wirklich löschen?</string>
     <string name="question_delete_group">Willst du diese Gruppe mit allen Feeds wirklich löschen?</string>
@@ -77,9 +77,9 @@
     <string name="menu_unstar">Entfavorisieren</string>
     <string name="menu_share">Teilen</string>
     <string name="menu_mark_as_unread">Als ungelesen markieren</string>
-    <string name="get_full_text">Vollen Text abrufen</string>
+    <string name="get_full_text">Ganzen Text abrufen</string>
     <string name="original_text">Ursprünglichen Text anzeigen</string>
-	<string name="open_in_browser">Im Browser ansehen</string>
+    <string name="open_in_browser">Im Browser ansehen</string>
     <string name="cant_open_link">Keine Anwendung für diesen Link gefunden</string>
     <string name="unreads">Ungelesen</string>
     <string name="all">Alle</string>


### PR DESCRIPTION
The current translation would be something like "activate full text search" in English. Also, it doesn't match the text of the button in the feed view.