### PR TITLE
Fix PRE formatting in RTL layout

### DIFF
--- a/app/src/main/java/net/frju/flym/ui/entrydetails/EntryDetailsView.kt
+++ b/app/src/main/java/net/frju/flym/ui/entrydetails/EntryDetailsView.kt
@@ -58,7 +58,7 @@ class EntryDetailsView @JvmOverloads constructor(context: Context, attrs: Attrib
             "a {color: #0099CC}" +
             "h1 a {color: inherit; text-decoration: none}" +
             "img {height: auto} " +
-            "pre {white-space: pre-wrap;} " +
+            "pre {white-space: pre-wrap; direction: ltr;} " +
             "blockquote {border-left: thick solid " + QUOTE_LEFT_COLOR + "; background-color:" + QUOTE_BACKGROUND_COLOR + "; margin: 0.5em 0 0.5em 0em; padding: 0.5em} " +
             "p {margin: 0.8em 0 0.8em 0} " +
             "p.subtitle {color: " + SUBTITLE_COLOR + "; border-top:1px " + SUBTITLE_BORDER_COLOR + "; border-bottom:1px " + SUBTITLE_BORDER_COLOR + "; padding-top:2px; padding-bottom:2px; font-weight:800 } " +


### PR DESCRIPTION
I have noticed in RTL layout, `<pre>` tag needs a fix. I added css direction style into it. Screenshot it provided as reference for before/after:

![flym-pre-ltr-rtl-fix](https://user-images.githubusercontent.com/11241315/50982999-b4990580-1513-11e9-94cb-1282f7ddfd9c.png)
