### PR TITLE
Propose independent 'delete old entries' options applied to read and unread entries.

### DIFF
--- a/app/src/main/java/net/frju/flym/data/dao/EntryDao.kt
+++ b/app/src/main/java/net/frju/flym/data/dao/EntryDao.kt
@@ -141,8 +141,8 @@ interface EntryDao {
 	@Query("UPDATE entries SET favorite = 0 WHERE id IS :id")
 	fun markAsNotFavorite(id: String)
 
-	@Query("DELETE FROM entries WHERE fetchDate < :keepDateBorderTime AND favorite = 0 AND read = 1")
-	fun deleteOlderThan(keepDateBorderTime: Long)
+	@Query("DELETE FROM entries WHERE fetchDate < :keepDateBorderTime AND favorite = 0 AND read = :read")
+	fun deleteOlderThan(keepDateBorderTime: Long, read: Long)
 
 	@Insert(onConflict = OnConflictStrategy.IGNORE) // Ignore because we don't want to delete previously starred entries
 	fun insert(vararg entries: Entry)

--- a/app/src/main/java/net/frju/flym/data/utils/PrefConstants.kt
+++ b/app/src/main/java/net/frju/flym/data/utils/PrefConstants.kt
@@ -41,6 +41,7 @@ object PrefConstants {
     const val FILTER_KEYWORDS = "filter_keywords"
 
     const val KEEP_TIME = "keep_time"
+    const val KEEP_TIME_UNREAD = "keep_time_unread"
 
     const val FONT_SIZE = "font_size"
 

--- a/app/src/main/java/net/frju/flym/service/FetcherService.kt
+++ b/app/src/main/java/net/frju/flym/service/FetcherService.kt
@@ -134,7 +134,11 @@ class FetcherService : IntentService(FetcherService::class.java.simpleName) {
                     val keepTime = context.getPrefString(PrefConstants.KEEP_TIME, "4").toLong() * 86400000L
                     val keepDateBorderTime = if (keepTime > 0) System.currentTimeMillis() - keepTime else 0
 
-                    deleteOldEntries(keepDateBorderTime)
+                    val keepTimeUnread = context.getPrefString(PrefConstants.KEEP_TIME_UNREAD, "0").toLong() * 86400000L
+                    val keepDateBorderTimeUnread = if (keepTimeUnread > 0) System.currentTimeMillis() - keepTimeUnread else 0
+
+                    deleteOldEntries(keepDateBorderTime, 1);
+                    deleteOldEntries(keepDateBorderTimeUnread, 0);
                     COOKIE_MANAGER.cookieStore.removeAll() // Cookies are important for some sites, but we clean them each times
 
                     var newCount = 0
@@ -468,9 +472,9 @@ class FetcherService : IntentService(FetcherService::class.java.simpleName) {
             return entries.size
         }
 
-        private fun deleteOldEntries(keepDateBorderTime: Long) {
+        private fun deleteOldEntries(keepDateBorderTime: Long, read:Long) {
             if (keepDateBorderTime > 0) {
-                App.db.entryDao().deleteOlderThan(keepDateBorderTime)
+                App.db.entryDao().deleteOlderThan(keepDateBorderTime, read)
                 // Delete the cache files
                 deleteEntriesImagesCache(keepDateBorderTime)
             }

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -73,6 +73,7 @@
     <string name="settings_refresh_interval">Interval osveženja</string>
     <string name="settings_category_content_presentation">Prikaz sadržaja</string>
     <string name="settings_keep_time">Vreme čuvanja članaka</string>
+    <string name="settings_keep_time_unread">Time that the unread entries will be kept</string>
     <string name="settings_display_images">Prikaži slike</string>
     <string name="settings_display_images_description">Prikaži slike unutar članaka</string>
     <string name="settings_preload_image_mode">Unapred učitaj slike</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -79,6 +79,7 @@
     <string name="settings_refresh_interval">Interval entre actualitzacions</string>
     <string name="settings_category_content_presentation">Presentació del contingut</string>
     <string name="settings_keep_time">Temps de conservació d\'entrades</string>
+    <string name="settings_keep_time_unread">Time that the unread entries will be kept</string>
     <string name="settings_display_images">Mostra imatges</string>
     <string name="settings_display_images_description">Mostra imatges a les entrades</string>
     <string name="settings_preload_image_mode">Precàrrega d\'imatges</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -102,6 +102,7 @@
     <string name="settings_refresh_interval">Interval načítání</string>
     <string name="settings_category_content_presentation">Prezentace obsahu</string>
     <string name="settings_keep_time">Čas po který budou články uloženy</string>
+    <string name="settings_keep_time_unread">Time that the unread entries will be kept</string>
     <string name="settings_display_images">Zobrazovat obrázky</string>
     <string name="settings_display_images_description">Zobrazovat obrázky ve článcích</string>
     <string name="settings_preload_image_mode">Načítat obrázky</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -96,6 +96,7 @@
     <string name="settings_refresh_interval">Aktualisierungsintervall</string>
     <string name="settings_category_content_presentation">Anzeige der Inhalte</string>
     <string name="settings_keep_time">Zeit nach der Einträge gelöscht werden</string>
+    <string name="settings_keep_time_unread">Time that the unread entries will be kept</string>
     <string name="settings_display_images">Bilder anzeigen</string>
     <string name="settings_display_images_description">Bilder in den Einträgen anzeigen</string>
     <string name="settings_preload_image_mode">Bilder vorab laden</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -99,6 +99,7 @@
     <string name="settings_refresh_interval">Intervalo entre actualizaciones</string>
     <string name="settings_category_content_presentation">Modo de presentación</string>
     <string name="settings_keep_time">Tiempo de retención de las entradas</string>
+    <string name="settings_keep_time_unread">Time that the unread entries will be kept</string>
     <string name="settings_display_images">Mostrar imágenes</string>
     <string name="settings_display_images_description">Mostrar imágenes en artículos</string>
     <string name="settings_preload_image_mode">Precargar imágenes</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -101,6 +101,7 @@
     <string name="settings_refresh_interval">Freskatze tartea</string>
     <string name="settings_category_content_presentation">Edukien aurkezpena</string>
     <string name="settings_keep_time">Sarrerak gordeta mantenduko diren denbora</string>
+    <string name="settings_keep_time_unread">Time that the unread entries will be kept</string>
     <string name="settings_display_images">Irudiak erakutsi</string>
     <string name="settings_display_images_description">Irudiak erakutsi sarreretan</string>
     <string name="settings_preload_image_mode">Irudiak aurretik kargatu</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -97,6 +97,7 @@
     <string name="settings_refresh_interval">Päivitysväli</string>
     <string name="settings_category_content_presentation">Sisällön esittäminen</string>
     <string name="settings_keep_time">Artikkelien säilyttämisaika</string>
+    <string name="settings_keep_time_unread">Time that the unread entries will be kept</string>
     <string name="settings_display_images">Näytä kuvat</string>
     <string name="settings_display_images_description">Näytä kuvat artikkeleissa</string>
     <string name="settings_preload_image_mode">Esilataa kuvat</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -94,6 +94,7 @@
     <string name="settings_refresh_interval">Intervalle de mise à jour</string>
     <string name="settings_category_content_presentation">Présentation des flux</string>
     <string name="settings_keep_time">Délai de conservation des flux</string>
+    <string name="settings_keep_time_unread">Time that the unread entries will be kept</string>
     <string name="settings_display_images">Afficher les images</string>
     <string name="settings_display_images_description">Afficher les images dans les articles</string>
     <string name="settings_preload_image_mode">Préchargement des images</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -94,6 +94,7 @@
     <string name="settings_refresh_interval">Intervallo</string>
     <string name="settings_category_content_presentation">Aspetto e contenuti</string>
     <string name="settings_keep_time">Tempo di archiviazione</string>
+    <string name="settings_keep_time_unread">Time that the unread entries will be kept</string>
     <string name="settings_display_images">Mostra immagini</string>
     <string name="settings_display_images_description">Mostra le immagini degli articoli</string>
     <string name="settings_preload_image_mode">Scarica le immagini in anticipo</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -94,6 +94,7 @@
     <string name="settings_refresh_interval">새로 고침 간격</string>
     <string name="settings_category_content_presentation">내용 표시</string>
     <string name="settings_keep_time">항목을 저장할 시간</string>
+    <string name="settings_keep_time_unread">Time that the unread entries will be kept</string>
     <string name="settings_display_images">이미지 표시</string>
     <string name="settings_display_images_description">항목에서 이미지 표시</string>
     <string name="settings_preload_image_mode">이미지 미리 읽기</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -73,6 +73,7 @@
     <string name="settings_refresh_interval">Ververstussenpoos</string>
     <string name="settings_category_content_presentation">Inhoudsweergave</string>
     <string name="settings_keep_time">Hoe lang items moeten worden bewaard</string>
+    <string name="settings_keep_time_unread">Time that the unread entries will be kept</string>
     <string name="settings_display_images">Afbeeldingen tonen</string>
     <string name="settings_display_images_description">Afbeeldingen tonen in feeditems</string>
     <string name="settings_preload_image_mode">Afbeeldingen vooraf inladen</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -93,6 +93,7 @@
     <string name="settings_refresh_interval">Intervalo de atualização</string>
     <string name="settings_category_content_presentation">Apresentação de conteúdo</string>
     <string name="settings_keep_time">Tempo que as entradas vão permanecer</string>
+    <string name="settings_keep_time_unread">Time that the unread entries will be kept</string>
     <string name="settings_display_images">Mostrar imagens</string>
     <string name="settings_display_images_description">Mostrar imagens nas entradas</string>
     <string name="settings_preload_image_mode">Pré-carregar imagens</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -101,6 +101,7 @@
     <string name="settings_refresh_interval">Интервал обновления</string>
     <string name="settings_category_content_presentation">Представление содержания</string>
     <string name="settings_keep_time">Время хранения новостей</string>
+    <string name="settings_keep_time_unread">Time that the unread entries will be kept</string>
     <string name="settings_display_images">Показывать изображения</string>
     <string name="settings_display_images_description">Показывать изображения в новостях</string>
     <string name="settings_preload_image_mode">Предварительно загружать изображения</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -95,6 +95,7 @@
     <string name="settings_refresh_interval">Interval načítavania</string>
     <string name="settings_category_content_presentation">Prezentácia obsahu</string>
     <string name="settings_keep_time">Čas na ktorý budú články uložené</string>
+    <string name="settings_keep_time_unread">Time that the unread entries will be kept</string>
     <string name="settings_display_images">Zobrazovať obrázky</string>
     <string name="settings_display_images_description">Zobrazovať obrázky v článkoch</string>
     <string name="settings_preload_image_mode">Načítať obrázky</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -73,6 +73,7 @@
     <string name="settings_refresh_interval">Интервал освежења</string>
     <string name="settings_category_content_presentation">Приказ садржаја</string>
     <string name="settings_keep_time">Време чувања чланака</string>
+    <string name="settings_keep_time_unread">Time that the unread entries will be kept</string>
     <string name="settings_display_images">Прикажи слике</string>
     <string name="settings_display_images_description">Прикажи слике унутар чланака</string>
     <string name="settings_preload_image_mode">Унапред учитај слике</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -93,6 +93,7 @@
     <string name="settings_refresh_interval">Uppdateringsintervall</string>
     <string name="settings_category_content_presentation">Innehållspresentation</string>
     <string name="settings_keep_time">Tid som inläggen behållas</string>
+    <string name="settings_keep_time_unread">Time that the unread entries will be kept</string>
     <string name="settings_display_images">Visa bilder</string>
     <string name="settings_display_images_description">Visa bilder i inlägg</string>
     <string name="settings_preload_image_mode">Förladda bilder</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -93,7 +93,8 @@
     <string name="settings_refresh_enabled_description">开启自动刷新</string>
     <string name="settings_refresh_interval">刷新间隔</string>
     <string name="settings_category_content_presentation">内容介绍</string>
-    <string name="settings_keep_time">文章保存时间</string>
+    <string name="settings_keep_time">已读文章保存时间</string>
+    <string name="settings_keep_time_unread">未读文章保存时间</string>
     <string name="settings_display_images">显示图片</string>
     <string name="settings_display_images_description">在文章中显示图片</string>
     <string name="settings_preload_image_mode">预先加载图片</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,7 +72,8 @@
     <string name="settings_refresh_enabled_description">Enable the automatic refresh of feeds</string>
     <string name="settings_refresh_interval">Refresh interval</string>
     <string name="settings_category_content_presentation">Content presentation</string>
-    <string name="settings_keep_time">Time that the entries will be kept</string>
+    <string name="settings_keep_time">Time that the read entries will be kept</string>
+    <string name="settings_keep_time_unread">Time that the unread entries will be kept</string>
     <string name="settings_display_images">Display images</string>
     <string name="settings_display_images_description">Display images in entries</string>
     <string name="settings_preload_image_mode">Preload images</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -67,6 +67,15 @@
             android:inputType="number"
             android:key="keep_time"
             android:title="@string/settings_keep_time" />
+        <net.frju.flym.ui.views.AutoSummaryListPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="0"
+            android:entries="@array/settings_keep_times"
+            android:entryValues="@array/settings_keep_time_values"
+            android:inputType="number"
+            android:key="keep_time_unread"
+            android:title="@string/settings_keep_time_unread" />
 
         <net.frju.flym.ui.views.AutoSummaryListPreference
             android:layout_width="wrap_content"


### PR DESCRIPTION
Following pull request https://github.com/FredJul/Flym/pull/445, Here is a proposal to add independent  'delete old entries' options applied read and unread entries.
The reason behind this is that, for users subscribed to frequently updated feeders, as long as feeder grows, the list and app itself become large and slow. It's better to add an independent option 'delete old unread entries'. In default, this option is set to 'Forever', which does not affect current users.
The translation job was made for English and Chinese.