### PR TITLE
Add a debug build variant

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,6 +56,14 @@ android {
 			proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
 			signingConfig signingConfigs.release
 		}
+		debug {
+			applicationIdSuffix ".debug"
+			versionNameSuffix "-debug"
+			minifyEnabled false
+			shrinkResources false
+			debuggable true
+			signingConfig signingConfigs.debug
+		}
 	}
 
 	sourceSets {

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="app_name">Flym-Debug</string>
+</resources>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -119,7 +119,7 @@
 
 		<provider
 			android:name="androidx.core.content.FileProvider"
-			android:authorities="net.frju.flym.fileprovider"
+			android:authorities="${applicationId}.fileprovider"
 			android:exported="false"
 			android:grantUriPermissions="true">
 			<meta-data


### PR DESCRIPTION
Add a debug build variant to enable side-by-side installation of production and test versions of the app during development