### PR TITLE
Reorder settings

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -161,4 +161,5 @@
         <item>Dunkel</item>
         <item>Schwarz</item>
     </string-array>
+    <string name="settings_category_keep_time">Zeit, in der Einträge erhalten bleiben</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -166,5 +166,6 @@
         <item>Oscuro</item>
         <item>Negro</item>
     </string-array>
+    <string name="settings_category_keep_time">Tiempo de retención de artículos</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,9 +74,12 @@
     <string name="settings_refresh_enable_notifications">Display refresh notifications</string>
     <string name="settings_refresh_enable_notifications_description">Show a system notification when a refresh is completed</string>
     <string name="settings_refresh_interval">Refresh interval</string>
-    <string name="settings_category_content_presentation">Content presentation</string>
+
+    <string name="settings_category_keep_time">Time to keep entries</string>
     <string name="settings_keep_time">Time that read entries will be kept</string>
     <string name="settings_keep_time_unread">Time that unread entries will be kept</string>
+
+    <string name="settings_category_content_presentation">Content presentation</string>
     <string name="settings_display_images">Display images</string>
     <string name="settings_display_images_description">Display images in entries</string>
     <string name="settings_preload_image_mode">Preload images</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -6,55 +6,6 @@
     <PreferenceCategory
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:title="@string/settings_category_refresh">
-
-        <CheckBoxPreference
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:defaultValue="true"
-            android:key="refresh_enabled"
-            android:summary="@string/settings_refresh_enabled_description"
-            android:title="@string/settings_refresh_enabled" />
-
-        <CheckBoxPreference
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:defaultValue="true"
-            android:key="enable_refresh_notification"
-            android:summary="@string/settings_refresh_enable_notifications_description"
-            android:title="@string/settings_refresh_enable_notifications" />
-
-        <net.frju.flym.ui.views.AutoSummaryListPreference
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:defaultValue="7200"
-            android:dependency="refresh_enabled"
-            android:entries="@array/settings_intervals"
-            android:entryValues="@array/settings_interval_values"
-            android:inputType="number"
-            android:key="refresh_interval"
-            android:title="@string/settings_refresh_interval" />
-
-        <CheckBoxPreference
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:defaultValue="false"
-            android:key="refresh_wifi_only"
-            android:summary="@string/settings_refresh_wifi_only_description"
-            android:title="@string/settings_refresh_wifi_only" />
-
-        <CheckBoxPreference
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:defaultValue="true"
-            android:key="refresh_on_startup"
-            android:summary="@string/refresh_on_startup"
-            android:title="@string/refresh_on_startup_title"/>
-    </PreferenceCategory>
-
-    <PreferenceCategory
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
         android:title="@string/settings_category_content_presentation">
 
         <net.frju.flym.ui.views.AutoSummaryListPreference
@@ -66,24 +17,6 @@
             android:inputType="text"
             android:key="theme"
             android:title="@string/settings_theme" />
-        <net.frju.flym.ui.views.AutoSummaryListPreference
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:defaultValue="4"
-            android:entries="@array/settings_keep_times"
-            android:entryValues="@array/settings_keep_time_values"
-            android:inputType="number"
-            android:key="keep_time"
-            android:title="@string/settings_keep_time" />
-        <net.frju.flym.ui.views.AutoSummaryListPreference
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:defaultValue="0"
-            android:entries="@array/settings_keep_times"
-            android:entryValues="@array/settings_keep_time_values"
-            android:inputType="number"
-            android:key="keep_time_unread"
-            android:title="@string/settings_keep_time_unread" />
 
         <net.frju.flym.ui.views.AutoSummaryListPreference
             android:layout_width="wrap_content"
@@ -122,6 +55,81 @@
             android:summary="@string/open_browser_direct"
             android:title="@string/open_browser_direct_title" />
 
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:title="@string/settings_category_refresh">
+
+        <CheckBoxPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="true"
+            android:key="refresh_enabled"
+            android:summary="@string/settings_refresh_enabled_description"
+            android:title="@string/settings_refresh_enabled" />
+
+        <net.frju.flym.ui.views.AutoSummaryListPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="7200"
+            android:dependency="refresh_enabled"
+            android:entries="@array/settings_intervals"
+            android:entryValues="@array/settings_interval_values"
+            android:inputType="number"
+            android:key="refresh_interval"
+            android:title="@string/settings_refresh_interval" />
+
+        <CheckBoxPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="true"
+            android:key="enable_refresh_notification"
+            android:summary="@string/settings_refresh_enable_notifications_description"
+            android:title="@string/settings_refresh_enable_notifications" />
+
+        <CheckBoxPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="false"
+            android:key="refresh_wifi_only"
+            android:summary="@string/settings_refresh_wifi_only_description"
+            android:title="@string/settings_refresh_wifi_only" />
+
+        <CheckBoxPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="true"
+            android:key="refresh_on_startup"
+            android:summary="@string/refresh_on_startup"
+            android:title="@string/refresh_on_startup_title"/>
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:title="@string/settings_category_keep_time">
+
+        <net.frju.flym.ui.views.AutoSummaryListPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="4"
+            android:entries="@array/settings_keep_times"
+            android:entryValues="@array/settings_keep_time_values"
+            android:inputType="number"
+            android:key="keep_time"
+            android:title="@string/settings_keep_time" />
+
+        <net.frju.flym.ui.views.AutoSummaryListPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="0"
+            android:entries="@array/settings_keep_times"
+            android:entryValues="@array/settings_keep_time_values"
+            android:inputType="number"
+            android:key="keep_time_unread"
+            android:title="@string/settings_keep_time_unread" />
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -85,9 +85,18 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:defaultValue="true"
+            android:dependency="refresh_enabled"
             android:key="enable_refresh_notification"
             android:summary="@string/settings_refresh_enable_notifications_description"
             android:title="@string/settings_refresh_enable_notifications" />
+
+        <CheckBoxPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="true"
+            android:key="refresh_on_startup"
+            android:summary="@string/refresh_on_startup"
+            android:title="@string/refresh_on_startup_title"/>
 
         <CheckBoxPreference
             android:layout_width="wrap_content"
@@ -97,13 +106,6 @@
             android:summary="@string/settings_refresh_wifi_only_description"
             android:title="@string/settings_refresh_wifi_only" />
 
-        <CheckBoxPreference
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:defaultValue="true"
-            android:key="refresh_on_startup"
-            android:summary="@string/refresh_on_startup"
-            android:title="@string/refresh_on_startup_title"/>
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Hello,
I was thinking about Flym's settings and how a normal user might use them. That led me to reorder and regroup some of the settings, very small changes overall though:

- Move the "content presentation" to the top. With Dark mode etc. coming to all apps right now, many users will be searching for this functionality and I think this should be presented on top, alongside all the other custimization options (first thing to go to for most users).
- Move the "time to keep entries" to its own section, because is does not really have that much to do with the other presentation settings.
- Reorder some "automated refresh" entries to better highlight the logical connections and add dependency to "display refresh notifications".

![screenshot_flym_settings](https://user-images.githubusercontent.com/46764284/77247096-07993d00-6c2e-11ea-9fef-9593c1c073d8.png)

