### PR TITLE
Add red dot to menu button when feeds have fetching error

### DIFF
--- a/app/src/main/java/net/frju/flym/ui/main/MainActivity.kt
+++ b/app/src/main/java/net/frju/flym/ui/main/MainActivity.kt
@@ -155,9 +155,11 @@ class MainActivity : AppCompatActivity(), MainNavigator, AnkoLogger {
 					if (hasFetchingError()) {
 						drawer_hint.textColor = Color.RED
 						drawer_hint.textResource = R.string.drawer_fetch_error_explanation
+						toolbar.setNavigationIcon(R.drawable.ic_menu_red_highlight_24dp)
 					} else {
 						drawer_hint.textColor = Color.WHITE
 						drawer_hint.textResource = R.string.drawer_explanation
+						toolbar.setNavigationIcon(R.drawable.ic_menu_24dp)
 					}
 				}
 

--- a/app/src/main/res/drawable/ic_menu_red_highlight_24dp.xml
+++ b/app/src/main/res/drawable/ic_menu_red_highlight_24dp.xml
@@ -1,0 +1,17 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <group>
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M3,18h18v-2L3,16v2zM3,13h18v-2L3,11v2zM3,6v2h18L21,6L3,6z" />
+
+        <path
+            android:fillColor="#FF0000"
+            android:pathData="M27,5 m-10,0
+                            a2,2 0,1 1,7 0
+                            a2,2 0,1 1,-7 0" />
+    </group>
+</vector>


### PR DESCRIPTION
When some feeds have a fetching error, is it shown in the navigation drawer (they are marked in red), but just looking at the entries list, one does not notice that some feeds may not have refreshed correctly.
This PR adds a little red dot to the menu icon, so that the user sees directly that something is wrong and taps on it to check it out.
Feedback on the dot size and color is welcome!

![Screenshot_1584904416](https://user-images.githubusercontent.com/46764284/77258317-32a97e00-6c7a-11ea-9ffc-475901f5f643.png)
