### PR TITLE
Modify build.gradle so local.properties is optional

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,8 +31,11 @@ android {
 		abortOnError true
 	}
 
+	File localProps = project.rootProject.file('local.properties')
 	Properties properties = new Properties()
-	properties.load(project.rootProject.file('local.properties').newDataInputStream())
+	if (localProps.exists()) {
+		properties.load(localProps.newDataInputStream())
+	}
 
 	signingConfigs {
 		debug {


### PR DESCRIPTION
I recently cloned your repository and tried to do a build. I had an error because the `local.properties` file didn't exist. This little change allows for builds to complete even if there is no `local.properties` file.