### PR TITLE
Add option to disable swipe when viewing entry

### DIFF
--- a/app/src/main/java/net/frju/flym/data/utils/PrefConstants.kt
+++ b/app/src/main/java/net/frju/flym/data/utils/PrefConstants.kt
@@ -50,4 +50,5 @@ object PrefConstants {
     const val HIDE_BUTTON_MARK_ALL_AS_READ = "hide_button_mark_all_as_read"
     const val SORT_ORDER = "sort_order"
 
+    const val ENABLE_SWIPE_ENTRY = "enable_swipe_entry"
 }

--- a/app/src/main/java/net/frju/flym/ui/entrydetails/EntryDetailsFragment.kt
+++ b/app/src/main/java/net/frju/flym/ui/entrydetails/EntryDetailsFragment.kt
@@ -34,6 +34,7 @@ import net.fred.feedex.R
 import net.frju.flym.App
 import net.frju.flym.data.entities.EntryWithFeed
 import net.frju.flym.data.utils.PrefConstants
+import net.frju.flym.data.utils.PrefConstants.ENABLE_SWIPE_ENTRY
 import net.frju.flym.service.FetcherService
 import net.frju.flym.ui.main.MainNavigator
 import net.frju.flym.utils.getPrefBoolean
@@ -41,6 +42,7 @@ import net.frju.flym.utils.isOnline
 import org.jetbrains.anko.attr
 import org.jetbrains.anko.doAsync
 import org.jetbrains.anko.support.v4.browse
+import org.jetbrains.anko.support.v4.defaultSharedPreferences
 import org.jetbrains.anko.support.v4.share
 import org.jetbrains.anko.support.v4.toast
 import org.jetbrains.anko.uiThread
@@ -89,8 +91,14 @@ class EntryDetailsFragment : Fragment() {
 	private var isMobilizing = false
 	private var preferFullText = true
 
-	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
+	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+		return if (defaultSharedPreferences.getBoolean(ENABLE_SWIPE_ENTRY, true)) {
 			inflater.inflate(R.layout.fragment_entry_details, container, false)
+		} else {
+			inflater.inflate(R.layout.fragment_entry_details_noswipe, container, false)
+		}
+
+	}
 
 	override fun onDestroyView() {
 		super.onDestroyView()
@@ -109,21 +117,23 @@ class EntryDetailsFragment : Fragment() {
 			switchFullTextMode()
 		}
 
-		swipe_view.swipeGestureListener = object : SwipeGestureListener {
-			override fun onSwipedLeft(@NotNull swipeActionView: SwipeActionView): Boolean {
-				nextId?.let { nextId ->
-					setEntry(nextId, allEntryIds)
-					navigator?.setSelectedEntryId(nextId)
+		if (defaultSharedPreferences.getBoolean(ENABLE_SWIPE_ENTRY, true)) {
+			swipe_view.swipeGestureListener = object : SwipeGestureListener {
+				override fun onSwipedLeft(@NotNull swipeActionView: SwipeActionView): Boolean {
+					nextId?.let { nextId ->
+						setEntry(nextId, allEntryIds)
+						navigator?.setSelectedEntryId(nextId)
+					}
+					return true
 				}
-				return true
-			}
 
-			override fun onSwipedRight(@NotNull swipeActionView: SwipeActionView): Boolean {
-				previousId?.let { previousId ->
-					setEntry(previousId, allEntryIds)
-					navigator?.setSelectedEntryId(previousId)
+				override fun onSwipedRight(@NotNull swipeActionView: SwipeActionView): Boolean {
+					previousId?.let { previousId ->
+						setEntry(previousId, allEntryIds)
+						navigator?.setSelectedEntryId(previousId)
+					}
+					return true
 				}
-				return true
 			}
 		}
 

--- a/app/src/main/res/layout/fragment_entry_details_noswipe.xml
+++ b/app/src/main/res/layout/fragment_entry_details_noswipe.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?android:attr/actionBarSize"
+            android:theme="@style/AppTheme.ActionBar.Details"/>
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <net.frju.flym.ui.views.SwipeRefreshLayout
+        android:id="@+id/refresh_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="?android:attr/actionBarSize">
+
+        <net.frju.flym.ui.entrydetails.EntryDetailsView
+            android:id="@+id/entry_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scrollbars="vertical" />
+    </net.frju.flym.ui.views.SwipeRefreshLayout>
+</FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,6 +98,8 @@
     <string name="settings_hide_button_mark_all_as_read_description">Don\'t show button \'Mark all as read\' on screen</string>
     <string name="settings_sort_order">Sort entries from newest to oldest</string>
     <string name="settings_sort_order_title">Sort order</string>
+    <string name="settings_enable_entry_swipe">Enable swipe while viewing an entry</string>
+    <string name="settings_enable_entry_swipe_description">If enabled, allows swiping between entries while viewing an entry.</string>
 
     <plurals name="number_of_new_entries">
         <item quantity="one">One new entry</item>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -71,6 +71,14 @@
             android:summary="@string/settings_sort_order"
             android:title="@string/settings_sort_order_title" />
 
+        <CheckBoxPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="true"
+            android:key="enable_swipe_entry"
+            android:summary="@string/settings_enable_entry_swipe_description"
+            android:title="@string/settings_enable_entry_swipe"/>
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Per issues #480 and #586, some people find the swipe gesture while viewing entries annoying. Give them a preference to disable it.

I didn't do a full-on regression test with this change. I merely tested with both the preference enabled and disabled. I also tried to follow convention when adding a new preference, but if you see changes that should be made, please let me know.