### PR TITLE
Fix resume intents to not retrigger a tab refresh when already on that tab

### DIFF
--- a/app/src/main/java/net/frju/flym/ui/main/MainActivity.kt
+++ b/app/src/main/java/net/frju/flym/ui/main/MainActivity.kt
@@ -320,6 +320,8 @@ class MainActivity : AppCompatActivity(), MainNavigator, AnkoLogger {
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
 
+        setIntent(intent)
+
         handleImplicitIntent(intent)
     }
 
@@ -352,19 +354,19 @@ class MainActivity : AppCompatActivity(), MainNavigator, AnkoLogger {
     private fun handleResumeOnlyIntents(intent: Intent?) {
 
         // If it comes from the All feeds App Shortcuts, select the right view
-        if (intent?.action.equals(INTENT_ALL)) {
+        if (intent?.action.equals(INTENT_ALL) && bottom_navigation.selectedItemId != R.id.all) {
             feedAdapter.selectedItemId = Feed.ALL_ENTRIES_ID
             bottom_navigation.selectedItemId = R.id.all
         }
 
         // If it comes from the Favorites feeds App Shortcuts, select the right view
-        if (intent?.action.equals(INTENT_FAVORITES)) {
+        if (intent?.action.equals(INTENT_FAVORITES) && bottom_navigation.selectedItemId != R.id.favorites) {
             feedAdapter.selectedItemId = Feed.ALL_ENTRIES_ID
             bottom_navigation.selectedItemId = R.id.favorites
         }
 
         // If it comes from the Unreads feeds App Shortcuts, select the right view
-        if (intent?.action.equals(INTENT_UNREADS)) {
+        if (intent?.action.equals(INTENT_UNREADS) && bottom_navigation.selectedItemId != R.id.unreads) {
             feedAdapter.selectedItemId = Feed.ALL_ENTRIES_ID
             bottom_navigation.selectedItemId = R.id.unreads
         }


### PR DESCRIPTION
This fixes an issue where the tab would refresh when going to an article and pressing back when you got to that tab using a shortcut intent. The current behavior would refresh the entire tab (ex. "All") when coming back from an article and scroll to the top. The new behavior will not refresh the tab in this case and preserve the current scroll position.

This bug can only be seen when using shortcut intents (on Android 7.1+, long hold the app icon and press "Unreads", "All", or "Favorites")

I also added the setIntent(intent) line in onNewIntent(...) because the intent was not being updated when the activity was already created. Adding this line ensures that the intent is always updated and will be correct in onResume(...)
(This was causing the incorrect tab to be loaded when trying to use multiple shortcuts in a row without force closing the app)