### PR TITLE
Hide toolbar when scrolling on entry details

### DIFF
--- a/app/src/main/java/net/frju/flym/data/utils/PrefConstants.kt
+++ b/app/src/main/java/net/frju/flym/data/utils/PrefConstants.kt
@@ -48,6 +48,7 @@ object PrefConstants {
 
     const val OPEN_BROWSER_DIRECTLY = "open_browser_directly"
     const val HIDE_BUTTON_MARK_ALL_AS_READ = "hide_button_mark_all_as_read"
+    const val HIDE_NAVIGATION_ON_SCROLL = "hide_navigation_on_scroll"
     const val SORT_ORDER = "sort_order"
 
     const val ENABLE_SWIPE_ENTRY = "enable_swipe_entry"

--- a/app/src/main/java/net/frju/flym/ui/entries/EntriesFragment.kt
+++ b/app/src/main/java/net/frju/flym/ui/entries/EntriesFragment.kt
@@ -21,16 +21,13 @@ import android.content.Intent
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener
 import android.os.Bundle
 import android.os.Handler
-import android.view.LayoutInflater
-import android.view.Menu
-import android.view.MenuInflater
-import android.view.MenuItem
-import android.view.View
-import android.view.ViewGroup
+import android.view.*
 import androidx.appcompat.widget.SearchView
+import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.os.bundleOf
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
+import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
@@ -39,6 +36,8 @@ import androidx.paging.PagedList
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.behavior.HideBottomViewOnScrollBehavior
+import com.google.android.material.bottomappbar.BottomAppBar
 import kotlinx.android.synthetic.main.fragment_entries.*
 import kotlinx.android.synthetic.main.view_entry.view.*
 import kotlinx.android.synthetic.main.view_main_containers.*
@@ -53,19 +52,15 @@ import net.frju.flym.utils.closeKeyboard
 import net.frju.flym.utils.getPrefBoolean
 import net.frju.flym.utils.registerOnPrefChangeListener
 import net.frju.flym.utils.unregisterOnPrefChangeListener
+import org.jetbrains.anko.*
 import org.jetbrains.anko.appcompat.v7.titleResource
-import org.jetbrains.anko.attr
-import org.jetbrains.anko.colorAttr
 import org.jetbrains.anko.design.longSnackbar
-import org.jetbrains.anko.doAsync
-import org.jetbrains.anko.notificationManager
 import org.jetbrains.anko.sdk21.listeners.onClick
 import org.jetbrains.anko.support.v4.dip
 import org.jetbrains.anko.support.v4.share
-import org.jetbrains.anko.uiThread
 import q.rorbin.badgeview.Badge
 import q.rorbin.badgeview.QBadgeView
-import java.util.Date
+import java.util.*
 
 
 class EntriesFragment : Fragment() {
@@ -184,7 +179,7 @@ class EntriesFragment : Fragment() {
                         }
                     }
 
-                    coordinator.longSnackbar(R.string.marked_as_read, R.string.undo) { _ ->
+                    inner_coordinator.longSnackbar(R.string.marked_as_read, R.string.undo) { _ ->
                         doAsync {
                             // TODO check if limit still needed
                             entryIds.withIndex().groupBy { it.index / 300 }.map { pair -> pair.value.map { it.value } }.forEach {
@@ -281,6 +276,20 @@ class EntriesFragment : Fragment() {
         } else {
             read_all_fab.visibility = View.VISIBLE;
         }
+
+        val params: CoordinatorLayout.LayoutParams = bottom_navigation.layoutParams as CoordinatorLayout.LayoutParams
+        if (context?.getPrefBoolean(PrefConstants.HIDE_NAVIGATION_ON_SCROLL, false) == true) {
+            recycler_view.updatePadding(bottom = (8 * resources.displayMetrics.density).toInt())
+            params.behavior = HideBottomViewOnScrollBehavior<BottomAppBar>()
+        } else {
+            recycler_view.updatePadding(bottom = (73 * resources.displayMetrics.density).toInt())
+            if (params.behavior is HideBottomViewOnScrollBehavior) {
+                (params.behavior as HideBottomViewOnScrollBehavior<View>).slideUp(bottom_navigation)
+            }
+            params.behavior = null
+        }
+        recycler_view.requestLayout()
+        bottom_navigation.requestLayout()
     }
 
     override fun onStop() {
@@ -338,7 +347,7 @@ class EntriesFragment : Fragment() {
                             App.db.entryDao().markAsUnread(listOf(entryWithFeed.entry.id))
                         }
 
-                        coordinator.longSnackbar(R.string.marked_as_read, R.string.undo) { _ ->
+                        inner_coordinator.longSnackbar(R.string.marked_as_read, R.string.undo) { _ ->
                             doAsync {
                                 if (entryWithFeed.entry.read) {
                                     App.db.entryDao().markAsUnread(listOf(entryWithFeed.entry.id))

--- a/app/src/main/res/layout/fragment_entries.xml
+++ b/app/src/main/res/layout/fragment_entries.xml
@@ -1,45 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/coordinator"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.coordinatorlayout.widget.CoordinatorLayout
-        android:id="@+id/coordinator"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginStart="0dp"
-        android:layout_marginTop="0dp"
-        android:layout_marginEnd="0dp"
-        app:layout_constraintBottom_toTopOf="@+id/bottom_navigation"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+    <net.frju.flym.ui.views.SwipeRefreshLayout
+        android:id="@+id/refresh_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
-        <net.frju.flym.ui.views.SwipeRefreshLayout
-            android:id="@+id/refresh_layout"
+        <net.frju.flym.ui.views.EmptyRecyclerView
+            android:id="@+id/recycler_view"
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:clipToPadding="false"
+            android:paddingTop="8dp"
+            android:paddingBottom="73dp"
+            android:scrollbars="vertical" />
+    </net.frju.flym.ui.views.SwipeRefreshLayout>
 
-            <net.frju.flym.ui.views.EmptyRecyclerView
-                android:id="@+id/recycler_view"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:clipToPadding="false"
-                android:paddingTop="8dp"
-                android:paddingBottom="60dp"
-                android:scrollbars="vertical" />
-        </net.frju.flym.ui.views.SwipeRefreshLayout>
+    <TextView
+        android:id="@+id/empty_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:drawableTop="@drawable/ic_empty_gray_100dp"
+        android:gravity="center"
+        android:text="@string/no_entries"
+        android:textColor="@android:color/darker_gray" />
 
-        <TextView
-            android:id="@+id/empty_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:drawableTop="@drawable/ic_empty_gray_100dp"
-            android:gravity="center"
-            android:text="@string/no_entries"
-            android:textColor="@android:color/darker_gray" />
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:id="@+id/inner_coordinator"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_dodgeInsetEdges="bottom">
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/read_all_fab"
@@ -53,18 +49,13 @@
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottom_navigation"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="65dp"
-        android:layout_marginStart="0dp"
-        android:layout_marginEnd="0dp"
-        android:layout_marginBottom="0dp"
+        android:layout_gravity="bottom"
         android:background="?attr/colorPrimary"
         app:itemIconTint="@color/bottom_navigation_item"
         app:itemTextColor="@color/bottom_navigation_item"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_insetEdge="bottom"
         app:menu="@menu/menu_bottom_navigation_items" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_entry_details.xml
+++ b/app/src/main/res/layout/fragment_entry_details.xml
@@ -1,49 +1,61 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<me.thanel.swipeactionview.SwipeActionView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/swipe_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <com.google.android.material.appbar.AppBarLayout
-        android:id="@+id/app_bar_layout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+    <ImageView
+        android:layout_width="50dp"
+        android:layout_height="50dp"
+        android:layout_gravity="center_vertical"
+        android:src="@drawable/ic_navigate_before_white_24dp" />
 
-        <androidx.appcompat.widget.Toolbar
-            android:id="@+id/toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="?android:attr/actionBarSize"
-            android:theme="@style/AppTheme.ActionBar.Details" />
+    <ImageView
+        android:layout_width="50dp"
+        android:layout_height="50dp"
+        android:layout_gravity="end|center_vertical"
+        android:src="@drawable/ic_navigate_next_white_24dp" />
 
-    </com.google.android.material.appbar.AppBarLayout>
-
-    <me.thanel.swipeactionview.SwipeActionView
-        android:id="@+id/swipe_view"
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:id="@+id/coordinator"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <ImageView
-            android:layout_width="50dp"
-            android:layout_height="50dp"
-            android:layout_gravity="center_vertical"
-            android:src="@drawable/ic_navigate_before_white_24dp" />
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/app_bar_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
 
-        <ImageView
-            android:layout_width="50dp"
-            android:layout_height="50dp"
-            android:layout_gravity="end|center_vertical"
-            android:src="@drawable/ic_navigate_next_white_24dp" />
+            <androidx.appcompat.widget.Toolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?android:attr/actionBarSize"
+                android:theme="@style/AppTheme.ActionBar.Details" />
+
+        </com.google.android.material.appbar.AppBarLayout>
 
         <net.frju.flym.ui.views.SwipeRefreshLayout
             android:id="@+id/refresh_layout"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginTop="?android:attr/actionBarSize">
+            app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-            <net.frju.flym.ui.entrydetails.EntryDetailsView
-                android:id="@+id/entry_view"
+            <androidx.core.widget.NestedScrollView
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:scrollbars="vertical" />
+                android:scrollbars="vertical">
+
+                <net.frju.flym.ui.entrydetails.EntryDetailsView
+                    android:id="@+id/entry_view"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+
+            </androidx.core.widget.NestedScrollView>
+
         </net.frju.flym.ui.views.SwipeRefreshLayout>
-    </me.thanel.swipeactionview.SwipeActionView>
-</FrameLayout>
+
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+
+</me.thanel.swipeactionview.SwipeActionView>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -8,6 +8,8 @@
 
     <color name="selected_item_background">#4c009789</color>
 
+    <color name="status_bar_background">#52000000</color>
+
     <!-- Dark Theme specific colors -->
     <color name="colorPrimaryDark">#00665C</color>
     <color name="colorBackground">#202020</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,6 +123,8 @@
     <string name="refresh_on_startup_title">Refresh on startup</string>
     <string name="settings_hide_button_mark_all_as_read">Hide button \'Mark all as read\'</string>
     <string name="settings_hide_button_mark_all_as_read_description">Don\'t show button \'Mark all as read\' on screen</string>
+    <string name="settings_hide_navigation_on_scroll">Hide navigation when scrolling</string>
+    <string name="settings_hide_navigation_on_scroll_description">If enabled, the top/bottom navigation will hide when scrolling down and reappear when scrolling up</string>
     <string name="settings_sort_order">Sort entries from newest to oldest</string>
     <string name="settings_sort_order_title">Sort order</string>
     <string name="settings_enable_entry_swipe">Enable swipe while viewing an entry</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -66,6 +66,14 @@
         <CheckBoxPreference
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:defaultValue="false"
+            android:key="hide_navigation_on_scroll"
+            android:summary="@string/settings_hide_navigation_on_scroll_description"
+            android:title="@string/settings_hide_navigation_on_scroll" />
+
+        <CheckBoxPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:defaultValue="true"
             android:key="sort_order"
             android:summary="@string/settings_sort_order"


### PR DESCRIPTION
Reorganizes the layout file for entry details so that the toolbar hides when scrolling down and reappears when scrolling up.

The only way to have this new layout work was to have the SwipeActionView at the top level, so now the toolbar also moves with the content when swiping between entries.

This is a very optional PR that only has to be merged in if you agree with this design change. I am planning on trying to make a PR that changes other pages to work in this same way with the toolbar, but it is trickier to refactor elsewhere to have this same toolbar hiding logic.

Also makes the top status bar and bottom navigation bar transparent when the hiding behavior is enabled.

Depends on https://github.com/FredJul/Flym/pull/648

![2020-08-27_15-10-48](https://user-images.githubusercontent.com/443370/91500155-c1e53e00-e877-11ea-93a9-b903b854f3b2.gif)
