### PR TITLE
Hide top navigation when scrolling on entries fragment

### DIFF
--- a/app/src/main/java/net/frju/flym/data/utils/PrefConstants.kt
+++ b/app/src/main/java/net/frju/flym/data/utils/PrefConstants.kt
@@ -48,6 +48,7 @@ object PrefConstants {
 
     const val OPEN_BROWSER_DIRECTLY = "open_browser_directly"
     const val HIDE_BUTTON_MARK_ALL_AS_READ = "hide_button_mark_all_as_read"
+    const val HIDE_NAVIGATION_ON_SCROLL = "hide_navigation_on_scroll"
     const val SORT_ORDER = "sort_order"
 
     const val ENABLE_SWIPE_ENTRY = "enable_swipe_entry"

--- a/app/src/main/java/net/frju/flym/ui/entries/EntriesFragment.kt
+++ b/app/src/main/java/net/frju/flym/ui/entries/EntriesFragment.kt
@@ -21,16 +21,13 @@ import android.content.Intent
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener
 import android.os.Bundle
 import android.os.Handler
-import android.view.LayoutInflater
-import android.view.Menu
-import android.view.MenuInflater
-import android.view.MenuItem
-import android.view.View
-import android.view.ViewGroup
+import android.view.*
 import androidx.appcompat.widget.SearchView
+import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.os.bundleOf
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
+import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
@@ -39,6 +36,8 @@ import androidx.paging.PagedList
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.behavior.HideBottomViewOnScrollBehavior
+import com.google.android.material.bottomappbar.BottomAppBar
 import kotlinx.android.synthetic.main.fragment_entries.*
 import kotlinx.android.synthetic.main.view_entry.view.*
 import kotlinx.android.synthetic.main.view_main_containers.*
@@ -53,19 +52,15 @@ import net.frju.flym.utils.closeKeyboard
 import net.frju.flym.utils.getPrefBoolean
 import net.frju.flym.utils.registerOnPrefChangeListener
 import net.frju.flym.utils.unregisterOnPrefChangeListener
+import org.jetbrains.anko.*
 import org.jetbrains.anko.appcompat.v7.titleResource
-import org.jetbrains.anko.attr
-import org.jetbrains.anko.colorAttr
 import org.jetbrains.anko.design.longSnackbar
-import org.jetbrains.anko.doAsync
-import org.jetbrains.anko.notificationManager
 import org.jetbrains.anko.sdk21.listeners.onClick
 import org.jetbrains.anko.support.v4.dip
 import org.jetbrains.anko.support.v4.share
-import org.jetbrains.anko.uiThread
 import q.rorbin.badgeview.Badge
 import q.rorbin.badgeview.QBadgeView
-import java.util.Date
+import java.util.*
 
 
 class EntriesFragment : Fragment() {
@@ -184,7 +179,7 @@ class EntriesFragment : Fragment() {
                         }
                     }
 
-                    coordinator.longSnackbar(R.string.marked_as_read, R.string.undo) { _ ->
+                    inner_coordinator.longSnackbar(R.string.marked_as_read, R.string.undo) { _ ->
                         doAsync {
                             // TODO check if limit still needed
                             entryIds.withIndex().groupBy { it.index / 300 }.map { pair -> pair.value.map { it.value } }.forEach {
@@ -281,6 +276,20 @@ class EntriesFragment : Fragment() {
         } else {
             read_all_fab.visibility = View.VISIBLE;
         }
+
+        val params: CoordinatorLayout.LayoutParams = bottom_navigation.layoutParams as CoordinatorLayout.LayoutParams
+        if (context?.getPrefBoolean(PrefConstants.HIDE_NAVIGATION_ON_SCROLL, false) == true) {
+            recycler_view.updatePadding(bottom = (8 * resources.displayMetrics.density).toInt())
+            params.behavior = HideBottomViewOnScrollBehavior<BottomAppBar>()
+        } else {
+            recycler_view.updatePadding(bottom = (73 * resources.displayMetrics.density).toInt())
+            if (params.behavior is HideBottomViewOnScrollBehavior) {
+                (params.behavior as HideBottomViewOnScrollBehavior<View>).slideUp(bottom_navigation)
+            }
+            params.behavior = null
+        }
+        recycler_view.requestLayout()
+        bottom_navigation.requestLayout()
     }
 
     override fun onStop() {
@@ -338,7 +347,7 @@ class EntriesFragment : Fragment() {
                             App.db.entryDao().markAsUnread(listOf(entryWithFeed.entry.id))
                         }
 
-                        coordinator.longSnackbar(R.string.marked_as_read, R.string.undo) { _ ->
+                        inner_coordinator.longSnackbar(R.string.marked_as_read, R.string.undo) { _ ->
                             doAsync {
                                 if (entryWithFeed.entry.read) {
                                     App.db.entryDao().markAsUnread(listOf(entryWithFeed.entry.id))

--- a/app/src/main/java/net/frju/flym/ui/main/ContainersLayout.kt
+++ b/app/src/main/java/net/frju/flym/ui/main/ContainersLayout.kt
@@ -35,6 +35,7 @@ import androidx.core.view.isVisible
 import androidx.interpolator.view.animation.FastOutLinearInInterpolator
 import androidx.interpolator.view.animation.LinearOutSlowInInterpolator
 import kotlinx.android.synthetic.main.view_main_containers.view.*
+import kotlinx.android.synthetic.main.fragment_entries.view.*
 import net.fred.feedex.R
 import net.frju.flym.utils.onLaidOut
 

--- a/app/src/main/java/net/frju/flym/ui/main/MainActivity.kt
+++ b/app/src/main/java/net/frju/flym/ui/main/MainActivity.kt
@@ -44,7 +44,6 @@ import com.rometools.rome.io.WireFeedOutput
 import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.android.synthetic.main.dialog_edit_feed.view.*
 import kotlinx.android.synthetic.main.fragment_entries.*
-import kotlinx.android.synthetic.main.view_main_containers.*
 import kotlinx.android.synthetic.main.view_main_drawer_header.*
 import net.fred.feedex.R
 import net.frju.flym.App
@@ -270,10 +269,6 @@ class MainActivity : AppCompatActivity(), MainNavigator, AnkoLogger {
             }
         })
 
-        setSupportActionBar(toolbar)
-        toolbar.setNavigationIcon(R.drawable.ic_menu_24dp)
-        toolbar.setNavigationOnClickListener { toggleDrawer() }
-
         if (savedInstanceState == null) {
             // First open => we open the drawer for you
             if (getPrefBoolean(PrefConstants.FIRST_OPEN, true)) {
@@ -313,7 +308,6 @@ class MainActivity : AppCompatActivity(), MainNavigator, AnkoLogger {
         AutoRefreshJobService.initAutoRefresh(this)
 
         handleImplicitIntent(intent)
-
     }
 
 
@@ -655,7 +649,7 @@ class MainActivity : AppCompatActivity(), MainNavigator, AnkoLogger {
         }
     }
 
-    private fun toggleDrawer() {
+    fun toggleDrawer() {
         if (drawer?.isDrawerOpen(GravityCompat.START) == true) {
             drawer?.closeDrawer(GravityCompat.START)
         } else {

--- a/app/src/main/res/layout-w840dp/view_main_containers.xml
+++ b/app/src/main/res/layout-w840dp/view_main_containers.xml
@@ -5,33 +5,11 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <LinearLayout
+    <androidx.cardview.widget.CardView
+        android:id="@+id/frame_master"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical">
-
-        <com.google.android.material.appbar.AppBarLayout
-            android:id="@+id/appbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:fitsSystemWindows="true"
-            android:stateListAnimator="@animator/appbar_always_elevated"
-            android:theme="@style/AppTheme.ActionBar">
-
-            <androidx.appcompat.widget.Toolbar
-                android:id="@+id/toolbar"
-                android:layout_width="match_parent"
-                android:layout_height="?android:attr/actionBarSize"
-                app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
-        </com.google.android.material.appbar.AppBarLayout>
-
-        <androidx.cardview.widget.CardView
-            android:id="@+id/frame_master"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:cardCornerRadius="0dp" />
-
-    </LinearLayout>
+        app:cardCornerRadius="0dp" />
 
     <androidx.cardview.widget.CardView
         android:id="@+id/frame_details"
@@ -41,4 +19,5 @@
         android:layout_marginEnd="@dimen/container_horizontal_padding_end"
         app:cardBackgroundColor="@color/colorBackground"
         app:cardElevation="3dp" />
+
 </FrameLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,7 +5,6 @@
     android:id="@+id/drawer"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
     tools:openDrawer="start">
 
     <net.frju.flym.ui.main.ContainersLayout
@@ -19,7 +18,6 @@
         android:layout_gravity="start"
         android:background="?attr/colorBackground"
         android:clickable="true"
-        android:fitsSystemWindows="true"
         android:focusable="true">
 
         <include

--- a/app/src/main/res/layout/fragment_entries.xml
+++ b/app/src/main/res/layout/fragment_entries.xml
@@ -6,19 +6,35 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:stateListAnimator="@animator/appbar_always_elevated">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?android:attr/actionBarSize"
+            android:theme="@style/AppTheme.ActionBar.Details" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
     <net.frju.flym.ui.views.SwipeRefreshLayout
         android:id="@+id/refresh_layout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
         <net.frju.flym.ui.views.EmptyRecyclerView
             android:id="@+id/recycler_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:clipToPadding="false"
-            android:paddingTop="8dp"
-            android:paddingBottom="73dp"
+            android:paddingTop="@dimen/recycler_view_vertical_padding"
+            android:paddingBottom="@dimen/recycler_view_bottom_padding_with_nav"
             android:scrollbars="vertical" />
+
     </net.frju.flym.ui.views.SwipeRefreshLayout>
 
     <TextView
@@ -50,7 +66,7 @@
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottom_navigation"
         android:layout_width="match_parent"
-        android:layout_height="65dp"
+        android:layout_height="@dimen/bottom_nav_height"
         android:layout_gravity="bottom"
         android:background="?attr/colorPrimary"
         app:itemIconTint="@color/bottom_navigation_item"

--- a/app/src/main/res/layout/fragment_entries.xml
+++ b/app/src/main/res/layout/fragment_entries.xml
@@ -1,45 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/coordinator"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.coordinatorlayout.widget.CoordinatorLayout
-        android:id="@+id/coordinator"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginStart="0dp"
-        android:layout_marginTop="0dp"
-        android:layout_marginEnd="0dp"
-        app:layout_constraintBottom_toTopOf="@+id/bottom_navigation"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+    <net.frju.flym.ui.views.SwipeRefreshLayout
+        android:id="@+id/refresh_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
-        <net.frju.flym.ui.views.SwipeRefreshLayout
-            android:id="@+id/refresh_layout"
+        <net.frju.flym.ui.views.EmptyRecyclerView
+            android:id="@+id/recycler_view"
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:clipToPadding="false"
+            android:paddingTop="8dp"
+            android:paddingBottom="73dp"
+            android:scrollbars="vertical" />
+    </net.frju.flym.ui.views.SwipeRefreshLayout>
 
-            <net.frju.flym.ui.views.EmptyRecyclerView
-                android:id="@+id/recycler_view"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:clipToPadding="false"
-                android:paddingTop="8dp"
-                android:paddingBottom="60dp"
-                android:scrollbars="vertical" />
-        </net.frju.flym.ui.views.SwipeRefreshLayout>
+    <TextView
+        android:id="@+id/empty_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:drawableTop="@drawable/ic_empty_gray_100dp"
+        android:gravity="center"
+        android:text="@string/no_entries"
+        android:textColor="@android:color/darker_gray" />
 
-        <TextView
-            android:id="@+id/empty_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:drawableTop="@drawable/ic_empty_gray_100dp"
-            android:gravity="center"
-            android:text="@string/no_entries"
-            android:textColor="@android:color/darker_gray" />
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:id="@+id/inner_coordinator"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_dodgeInsetEdges="bottom">
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/read_all_fab"
@@ -53,18 +49,13 @@
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottom_navigation"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="65dp"
-        android:layout_marginStart="0dp"
-        android:layout_marginEnd="0dp"
-        android:layout_marginBottom="0dp"
+        android:layout_gravity="bottom"
         android:background="?attr/colorPrimary"
         app:itemIconTint="@color/bottom_navigation_item"
         app:itemTextColor="@color/bottom_navigation_item"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_insetEdge="bottom"
         app:menu="@menu/menu_bottom_navigation_items" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/view_main_containers.xml
+++ b/app/src/main/res/layout/view_main_containers.xml
@@ -3,32 +3,10 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <LinearLayout
+    <FrameLayout
+        android:id="@+id/frame_master"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
-
-        <com.google.android.material.appbar.AppBarLayout
-            android:id="@+id/appbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:fitsSystemWindows="true"
-            android:stateListAnimator="@animator/appbar_always_elevated">
-
-            <androidx.appcompat.widget.Toolbar
-                android:id="@+id/toolbar"
-                android:layout_width="match_parent"
-                android:layout_height="?android:attr/actionBarSize"
-                android:theme="@style/AppTheme.ActionBar.Details" />
-        </com.google.android.material.appbar.AppBarLayout>
-
-        <FrameLayout
-            android:id="@+id/frame_master"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_gravity="center_horizontal" />
-
-    </LinearLayout>
+        android:layout_height="match_parent"/>
 
     <FrameLayout
         android:id="@+id/frame_details"
@@ -37,4 +15,5 @@
         android:layout_gravity="center_horizontal"
         android:background="@color/colorBackground"
         android:visibility="gone" />
+
 </FrameLayout>

--- a/app/src/main/res/layout/view_main_drawer_header.xml
+++ b/app/src/main/res/layout/view_main_drawer_header.xml
@@ -9,7 +9,7 @@
 
     <ImageView
         android:layout_width="0dp"
-        android:layout_height="136dp"
+        android:layout_height="wrap_content"
         android:scaleType="centerCrop"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
@@ -17,6 +17,13 @@
         app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@drawable/header_background"
         tools:ignore="ContentDescription" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_begin="0dp" />
 
     <TextView
         android:id="@+id/drawer_hint"
@@ -31,7 +38,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="@id/guideline" />
 
     <ImageView
         android:id="@+id/more"
@@ -40,7 +47,7 @@
         android:background="?android:selectableItemBackground"
         android:padding="16dp"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toTopOf="@id/guideline"
         app:srcCompat="@drawable/ic_more_vert_white_24dp"
         tools:ignore="ContentDescription" />
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -8,6 +8,8 @@
 
     <color name="selected_item_background">#4c009789</color>
 
+    <color name="status_bar_background">#52000000</color>
+
     <!-- Dark Theme specific colors -->
     <color name="colorPrimaryDark">#00665C</color>
     <color name="colorBackground">#202020</color>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -10,4 +10,8 @@
     <dimen name="entry_img_width">50dp</dimen>
     <dimen name="entry_img_height">50dp</dimen>
 
+    <dimen name="bottom_nav_height">65dp</dimen>
+    <dimen name="recycler_view_vertical_padding">8dp</dimen>
+    <dimen name="recycler_view_bottom_padding_with_nav">73dp</dimen>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,6 +123,8 @@
     <string name="refresh_on_startup_title">Refresh on startup</string>
     <string name="settings_hide_button_mark_all_as_read">Hide button \'Mark all as read\'</string>
     <string name="settings_hide_button_mark_all_as_read_description">Don\'t show button \'Mark all as read\' on screen</string>
+    <string name="settings_hide_navigation_on_scroll">Hide navigation when scrolling</string>
+    <string name="settings_hide_navigation_on_scroll_description">If enabled, the top/bottom navigation will hide when scrolling down and reappear when scrolling up</string>
     <string name="settings_sort_order">Sort entries from newest to oldest</string>
     <string name="settings_sort_order_title">Sort order</string>
     <string name="settings_enable_entry_swipe">Enable swipe while viewing an entry</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -66,6 +66,14 @@
         <CheckBoxPreference
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:defaultValue="false"
+            android:key="hide_navigation_on_scroll"
+            android:summary="@string/settings_hide_navigation_on_scroll_description"
+            android:title="@string/settings_hide_navigation_on_scroll" />
+
+        <CheckBoxPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:defaultValue="true"
             android:key="sort_order"
             android:summary="@string/settings_sort_order"


### PR DESCRIPTION
Hides the top toolbar when scrolling down and unhides it when scrolling up. Has the same behavior as the bottom navigation hiding behavior and they work at the same time. The settings toggle also controls both behaviors.

Also makes the top status bar and bottom navigation bar transparent when the hiding behavior is enabled.

Depends on https://github.com/FredJul/Flym/pull/648

![2020-08-27_15-04-10](https://user-images.githubusercontent.com/443370/91500186-d4f80e00-e877-11ea-9600-ce376e0fdce0.gif)
