### PR TITLE
Update to API 30 and use new APIs for fullscreen/system bars

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,11 +8,11 @@ androidExtensions {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
     defaultConfig {
         applicationId "net.frju.flym"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 33
         versionName "2.4.0"
     }

--- a/app/src/main/java/net/frju/flym/ui/about/AboutActivity.kt
+++ b/app/src/main/java/net/frju/flym/ui/about/AboutActivity.kt
@@ -52,8 +52,8 @@ class AboutActivity : AppCompatActivity() {
         setContentView(view)
     }
 
-    override fun onOptionsItemSelected(item: MenuItem?): Boolean {
-        when (item?.itemId) {
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        when (item.itemId) {
             android.R.id.home -> onBackPressed()
         }
 

--- a/app/src/main/java/net/frju/flym/ui/entrydetails/EntryDetailsActivity.kt
+++ b/app/src/main/java/net/frju/flym/ui/entrydetails/EntryDetailsActivity.kt
@@ -41,8 +41,8 @@ class EntryDetailsActivity : AppCompatActivity() {
         }
     }
 
-    override fun onOptionsItemSelected(item: MenuItem?): Boolean {
-        when (item?.itemId) {
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        when (item.itemId) {
             android.R.id.home -> onBackPressed()
         }
 

--- a/app/src/main/java/net/frju/flym/ui/feeds/FeedListEditActivity.kt
+++ b/app/src/main/java/net/frju/flym/ui/feeds/FeedListEditActivity.kt
@@ -35,8 +35,8 @@ class FeedListEditActivity : AppCompatActivity() {
         setContentView(R.layout.activity_feed_list_edit)
     }
 
-    override fun onOptionsItemSelected(item: MenuItem?): Boolean {
-        when (item?.itemId) {
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        when (item.itemId) {
             android.R.id.home -> onBackPressed()
         }
 

--- a/app/src/main/java/net/frju/flym/ui/main/MainActivity.kt
+++ b/app/src/main/java/net/frju/flym/ui/main/MainActivity.kt
@@ -317,7 +317,9 @@ class MainActivity : AppCompatActivity(), MainNavigator, AnkoLogger {
         if (intent?.action.equals(Intent.ACTION_SEND)) {
             if (intent?.hasExtra(Intent.EXTRA_TEXT) == true) {
                 val search = intent.getStringExtra(Intent.EXTRA_TEXT)
-                DiscoverActivity.newInstance(this, search)
+                if (search != null) {
+                    DiscoverActivity.newInstance(this, search)
+                }
             }
             setIntent(null)
         }

--- a/app/src/main/res/layout/fragment_entries.xml
+++ b/app/src/main/res/layout/fragment_entries.xml
@@ -47,21 +47,15 @@
         android:text="@string/no_entries"
         android:textColor="@android:color/darker_gray" />
 
-    <androidx.coordinatorlayout.widget.CoordinatorLayout
-        android:id="@+id/inner_coordinator"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:layout_dodgeInsetEdges="bottom">
-
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/read_all_fab"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="bottom|end"
-            android:layout_margin="16dp"
-            android:src="@drawable/ic_read_all_white_24dp" />
-
-    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/read_all_fab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp"
+        android:src="@drawable/ic_read_all_white_24dp"
+        app:layout_dodgeInsetEdges="bottom" />
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottom_navigation"
@@ -71,7 +65,7 @@
         android:background="?attr/colorPrimary"
         app:itemIconTint="@color/bottom_navigation_item"
         app:itemTextColor="@color/bottom_navigation_item"
-        app:layout_insetEdge="bottom"
-        app:menu="@menu/menu_bottom_navigation_items" />
+        app:menu="@menu/menu_bottom_navigation_items"
+        app:layout_insetEdge="bottom" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_entry_details_noswipe.xml
+++ b/app/src/main/res/layout/fragment_entry_details_noswipe.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/coordinator"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -20,7 +23,7 @@
         android:id="@+id/refresh_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginTop="?android:attr/actionBarSize">
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
         <androidx.core.widget.NestedScrollView
             android:layout_width="match_parent"
@@ -31,6 +34,9 @@
                 android:id="@+id/entry_view"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
+
         </androidx.core.widget.NestedScrollView>
+
     </net.frju.flym.ui.views.SwipeRefreshLayout>
-</FrameLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
API 30 deprecates a ton of things including the way to do fullscreen apps underneath the status bar/navigation bar. This updates the app to work on API 30 and adds if/else for these new inset/window APIs.

Also fixes a crash when swiping is disabled on entry fragment.