### PR TITLE
Expand app bar and scroll to top when swiping between entries

### DIFF
--- a/app/src/main/java/net/frju/flym/ui/entrydetails/EntryDetailsFragment.kt
+++ b/app/src/main/java/net/frju/flym/ui/entrydetails/EntryDetailsFragment.kt
@@ -136,6 +136,8 @@ class EntryDetailsFragment : Fragment() {
                     nextId?.let { nextId ->
                         setEntry(nextId, allEntryIds)
                         navigator?.setSelectedEntryId(nextId)
+                        app_bar_layout.setExpanded(true, true)
+                        nested_scroll_view.scrollTo(0, 0)
                     }
                     return true
                 }
@@ -144,6 +146,8 @@ class EntryDetailsFragment : Fragment() {
                     previousId?.let { previousId ->
                         setEntry(previousId, allEntryIds)
                         navigator?.setSelectedEntryId(previousId)
+                        app_bar_layout.setExpanded(true, true)
+                        nested_scroll_view.scrollTo(0, 0)
                     }
                     return true
                 }

--- a/app/src/main/res/layout/fragment_entry_details.xml
+++ b/app/src/main/res/layout/fragment_entry_details.xml
@@ -43,6 +43,7 @@
             app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
             <androidx.core.widget.NestedScrollView
+                android:id="@+id/nested_scroll_view"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:scrollbars="vertical">

--- a/app/src/main/res/layout/fragment_entry_details_noswipe.xml
+++ b/app/src/main/res/layout/fragment_entry_details_noswipe.xml
@@ -26,6 +26,7 @@
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
         <androidx.core.widget.NestedScrollView
+            android:id="@+id/nested_scroll_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:scrollbars="vertical">


### PR DESCRIPTION
When swiping between entries, the scroll position from the previous entry would be preserved when loading the new entry. Now it will always scroll to the top when swiping between entries. It will also now expand the app bar so that it will expand when hiding navigation when scrolling is enabled.

![2020-09-09_14-06-22](https://user-images.githubusercontent.com/443370/92655114-c103d180-f2a5-11ea-9076-8cfc5a667182.gif)
