### PR TITLE
Fix image loading on different origins and from cache

### DIFF
--- a/app/src/main/java/net/frju/flym/ui/entrydetails/EntryDetailsView.kt
+++ b/app/src/main/java/net/frju/flym/ui/entrydetails/EntryDetailsView.kt
@@ -83,6 +83,8 @@ class EntryDetailsView @JvmOverloads constructor(context: Context, attrs: Attrib
         isHorizontalScrollBarEnabled = false
         settings.useWideViewPort = false
         settings.cacheMode = WebSettings.LOAD_NO_CACHE
+        settings.mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
+        settings.allowFileAccess = true
 
         @SuppressLint("SetJavaScriptEnabled")
         settings.javaScriptEnabled = true


### PR DESCRIPTION
Images in many entries would not load because they are on different origins. Read more about this setting here:
https://developer.android.com/reference/android/webkit/WebSettings#MIXED_CONTENT_COMPATIBILITY_MODE

And there was also an issue that was causing images from cache to not be loadable in the webview. allowFileAccess=true allows local cache images to be loaded in the webview for entries.