### PR TITLE
Fix arrows to not show before content load and arrows to be black on light theme

### DIFF
--- a/app/src/main/java/net/frju/flym/ui/entrydetails/EntryDetailsFragment.kt
+++ b/app/src/main/java/net/frju/flym/ui/entrydetails/EntryDetailsFragment.kt
@@ -52,13 +52,11 @@ import net.frju.flym.service.FetcherService
 import net.frju.flym.ui.main.MainNavigator
 import net.frju.flym.utils.getPrefBoolean
 import net.frju.flym.utils.isOnline
-import org.jetbrains.anko.attr
-import org.jetbrains.anko.doAsync
+import org.jetbrains.anko.*
 import org.jetbrains.anko.support.v4.browse
 import org.jetbrains.anko.support.v4.defaultSharedPreferences
 import org.jetbrains.anko.support.v4.share
 import org.jetbrains.anko.support.v4.toast
-import org.jetbrains.anko.uiThread
 import org.jetbrains.annotations.NotNull
 
 
@@ -128,6 +126,11 @@ class EntryDetailsFragment : Fragment() {
 
         refresh_layout.setOnRefreshListener {
             switchFullTextMode()
+        }
+
+        if (defaultSharedPreferences.getString(PrefConstants.THEME, null) == "LIGHT") {
+            navigate_before?.imageResource = R.drawable.ic_navigate_before_black_24dp
+            navigate_next?.imageResource = R.drawable.ic_navigate_next_black_24dp
         }
 
         if (defaultSharedPreferences.getBoolean(ENABLE_SWIPE_ENTRY, true)) {

--- a/app/src/main/res/drawable/ic_navigate_before_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_navigate_before_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M15.41,7.41L14,6l-6,6 6,6 1.41,-1.41L10.83,12z" />
+</vector>

--- a/app/src/main/res/drawable/ic_navigate_next_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_navigate_next_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M10,6L8.59,7.41 13.17,12l-4.58,4.59L10,18l6,-6z" />
+</vector>

--- a/app/src/main/res/layout/fragment_entry_details.xml
+++ b/app/src/main/res/layout/fragment_entry_details.xml
@@ -7,12 +7,14 @@
     android:layout_height="match_parent">
 
     <ImageView
+        android:id="@+id/navigate_before"
         android:layout_width="50dp"
         android:layout_height="50dp"
         android:layout_gravity="center_vertical"
         android:src="@drawable/ic_navigate_before_white_24dp" />
 
     <ImageView
+        android:id="@+id/navigate_next"
         android:layout_width="50dp"
         android:layout_height="50dp"
         android:layout_gravity="end|center_vertical"
@@ -46,7 +48,8 @@
                 android:id="@+id/nested_scroll_view"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:scrollbars="vertical">
+                android:scrollbars="vertical"
+                android:background="?attr/colorBackground">
 
                 <net.frju.flym.ui.entrydetails.EntryDetailsView
                     android:id="@+id/entry_view"

--- a/app/src/main/res/layout/fragment_entry_details_noswipe.xml
+++ b/app/src/main/res/layout/fragment_entry_details_noswipe.xml
@@ -29,7 +29,8 @@
             android:id="@+id/nested_scroll_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:scrollbars="vertical">
+            android:scrollbars="vertical"
+            android:background="?attr/colorBackground">
 
             <net.frju.flym.ui.entrydetails.EntryDetailsView
                 android:id="@+id/entry_view"


### PR DESCRIPTION
### The arrows would briefly show up on screen before the entry loaded, and now the scroll view has a background set so that the arrows cannot be seen before the content is loaded.

before:
![2020-09-12_14-53-29](https://user-images.githubusercontent.com/443370/93005651-d0825500-f507-11ea-9bea-109b0aaed4cd.gif)

after:
![2020-09-12_14-52-44](https://user-images.githubusercontent.com/443370/93005653-d415dc00-f507-11ea-98bf-934a59fa17b3.gif)

### Second fix is that the arrows were always white, even on the LIGHT theme. This fixes that by making the arrows black when the light theme is currently being used.

before:
![screen](https://user-images.githubusercontent.com/443370/93005677-16d7b400-f508-11ea-8a4e-669e34d4cf29.png)

after:
![screen](https://user-images.githubusercontent.com/443370/93005657-dbd58080-f507-11ea-9a52-57847e5904f2.png)