### PR TITLE
Option to monitor network traffic

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -104,6 +104,7 @@ dependencies {
     def okhttp_version = '4.8.1'
     implementation "com.squareup.okhttp3:okhttp:$okhttp_version"
     implementation "com.squareup.okhttp3:okhttp-urlconnection:$okhttp_version"
+    api "com.github.ChuckerTeam.Chucker:library:3.1.2"
 
     def glide_version = '4.11.0'
     implementation "com.github.bumptech.glide:glide:$glide_version"

--- a/app/src/main/java/net/frju/flym/data/utils/PrefConstants.kt
+++ b/app/src/main/java/net/frju/flym/data/utils/PrefConstants.kt
@@ -29,6 +29,7 @@ object PrefConstants {
     const val REFRESH_INTERVAL = "refresh_interval"
     const val REFRESH_ON_STARTUP = "refresh_on_startup"
     const val REFRESH_WIFI_ONLY = "refresh_wifi_only"
+    const val REFRESH_ENABLE_DEBUG_TRAFFIC = "refresh_enable_debug_traffic"
 
     const val THEME = "theme"
     const val DISPLAY_IMAGES = "display_images"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,6 +111,8 @@
     <string name="settings_font_size">Text size</string>
     <string name="settings_refresh_wifi_only">Refresh only over Wi-Fi</string>
     <string name="settings_refresh_wifi_only_description">Automatic refresh will only be done if a Wi-Fi connection is available</string>
+    <string name="settings_refresh_enable_debug_traffic">Enable debug network traffic</string>
+    <string name="settings_refresh_enable_debug_traffic_description">If enabled, will log all network traffic during refresh. May require app restart.</string>
     <string name="settings_category_filter">Filters</string>
     <string name="settings_remove_duplicates_description_title">Remove duplicates</string>
     <string name="settings_remove_duplicates_description">Checks the title of newly-downloaded items and skips when one with the same title is already present</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -138,6 +138,14 @@
             android:summary="@string/settings_refresh_wifi_only_description"
             android:title="@string/settings_refresh_wifi_only" />
 
+        <CheckBoxPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="false"
+            android:key="refresh_enable_debug_traffic"
+            android:summary="@string/settings_refresh_enable_debug_traffic_description"
+            android:title="@string/settings_refresh_enable_debug_traffic" />
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Add a preference to monitor all network traffic. If the preference is enabled, all network traffic will be logged via third-party library named "Chucker".

Chucker captures all network traffic and provides notifications when traffic occurs. Clicking on the notification allows all network calls to be viewed. This can be helpful when trying to debug connection issues.

@FredJul I'm not sure if you think this would be useful for all users, or perhaps it's a bit too "geeky" for people who don't fully understand HTTP response codes and whatnot. I'll understand if you don't think this is a good option to have for all users.