### PR TITLE
Fix transparent status/navigation bars in landscape orientation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -109,7 +109,7 @@ dependencies {
     implementation "com.github.bumptech.glide:glide:$glide_version"
     kapt "com.github.bumptech.glide:compiler:$glide_version"
 
-    implementation 'androidx.core:core-ktx:1.3.1'
+    implementation 'androidx.core:core-ktx:1.5.0-alpha02'
     implementation 'androidx.paging:paging-runtime:2.1.2'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.1'
     implementation 'androidx.preference:preference:1.1.1'

--- a/app/src/main/java/net/frju/flym/ui/entrydetails/EntryDetailsFragment.kt
+++ b/app/src/main/java/net/frju/flym/ui/entrydetails/EntryDetailsFragment.kt
@@ -19,19 +19,15 @@ package net.frju.flym.ui.entrydetails
 
 import android.content.Intent
 import android.graphics.Color
-import android.os.Build
 import android.os.Bundle
-import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
-import android.view.View.*
 import android.view.ViewGroup
-import android.view.WindowInsets
 import android.widget.FrameLayout
+import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.os.bundleOf
-import androidx.core.view.updateLayoutParams
-import androidx.core.view.updatePadding
+import androidx.core.view.*
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
@@ -162,30 +158,21 @@ class EntryDetailsFragment : Fragment() {
                 scrollFlags = AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL or
                     AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER_ALWAYS
             }
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                activity?.window?.setDecorFitsSystemWindows(false)
-            } else {
-                @Suppress("DEPRECATION")
-                coordinator.systemUiVisibility =
-                        SYSTEM_UI_FLAG_LAYOUT_STABLE or SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+            activity?.window?.let {
+                WindowCompat.setDecorFitsSystemWindows(it, false)
             }
-            toolbar.setOnApplyWindowInsetsListener { v, insets ->
-                val (statusBarHeight, navigationBarHeight) = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                    val systemBarsInsets = insets.getInsets(WindowInsets.Type.systemBars())
-                    Pair(systemBarsInsets.top, systemBarsInsets.bottom)
-                } else {
-                    @Suppress("DEPRECATION")
-                    Pair(insets.systemWindowInsetTop, insets.systemWindowInsetBottom)
+            ViewCompat.setOnApplyWindowInsetsListener(toolbar) { _, insets ->
+                val systemInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+                app_bar_layout.updateLayoutParams<CoordinatorLayout.LayoutParams> {
+                    leftMargin = systemInsets.left
+                    rightMargin = systemInsets.right
                 }
-                toolbar.updatePadding(top = statusBarHeight)
                 toolbar.updateLayoutParams<AppBarLayout.LayoutParams> {
-                    val tv = TypedValue()
-                    if (activity?.theme?.resolveAttribute(R.attr.actionBarSize, tv, true) == true) {
-                        height = resources.getDimensionPixelSize(tv.resourceId) + statusBarHeight
-                    }
+                    topMargin = systemInsets.top
                 }
+                nested_scroll_view.updatePadding(left = systemInsets.left, right = systemInsets.right)
                 entry_view.updateLayoutParams<FrameLayout.LayoutParams> {
-                    bottomMargin = navigationBarHeight
+                    bottomMargin = systemInsets.bottom
                 }
                 insets
             }


### PR DESCRIPTION
The insets assumed a portrait only orientation of the device. Now it will work in any orientation and with the status/navgiation bars anywhere on the screen (left, right, top, bottom)

This also changes to using WindowInsetsCompat since that handles the deprecation cases automatically.

![2020-09-13_21-40-00](https://user-images.githubusercontent.com/443370/93044682-3eaf4080-f60a-11ea-9629-9c0e5d93b234.gif)
