### PR TITLE
Fix scroll flags when hide nav is turned off

### DIFF
--- a/app/src/main/java/net/frju/flym/ui/entries/EntriesFragment.kt
+++ b/app/src/main/java/net/frju/flym/ui/entries/EntriesFragment.kt
@@ -392,13 +392,11 @@ class EntriesFragment : Fragment() {
             }
             appbar.setExpanded(true, true)
             toolbar.updateLayoutParams<AppBarLayout.LayoutParams> {
+                scrollFlags = 0
                 topMargin = 0
             }
-            if (VERSION.SDK_INT >= VERSION_CODES.R) {
-                activity?.window?.setDecorFitsSystemWindows(true)
-            } else {
-                @Suppress("DEPRECATION")
-                coordinator.systemUiVisibility = 0
+            activity?.window?.let {
+                WindowCompat.setDecorFitsSystemWindows(it, true)
             }
             activity?.drawer_header?.findViewById<Guideline>(R.id.guideline)?.updateLayoutParams<ConstraintLayout.LayoutParams> {
                 guideBegin = 0


### PR DESCRIPTION
The scroll flags were not being removed properly when hide nav on scroll was turned off. Also replace one other deprecation case with compat that I missed.

![2020-09-14_16-07-26](https://user-images.githubusercontent.com/443370/93146840-ba5dcb80-f6a4-11ea-8de7-06ddfcc22a2f.gif)