### PR TITLE
Fix feed list to have proper bottom padding when navigation is transparent

### DIFF
--- a/app/src/main/java/net/frju/flym/ui/entries/EntriesFragment.kt
+++ b/app/src/main/java/net/frju/flym/ui/entries/EntriesFragment.kt
@@ -398,7 +398,7 @@ class EntriesFragment : Fragment(R.layout.fragment_entries) {
             activity?.drawer_header?.findViewById<Guideline>(R.id.guideline)?.updateLayoutParams<ConstraintLayout.LayoutParams> {
                 guideBegin = 0
             }
-            toolbar.setOnApplyWindowInsetsListener(null)
+            ViewCompat.setOnApplyWindowInsetsListener(toolbar, null)
             val tv = TypedValue()
             if (activity?.theme?.resolveAttribute(R.attr.colorPrimaryDark, tv, true) == true) {
                 activity?.window?.statusBarColor = tv.data

--- a/app/src/main/java/net/frju/flym/ui/main/MainActivity.kt
+++ b/app/src/main/java/net/frju/flym/ui/main/MainActivity.kt
@@ -30,8 +30,7 @@ import android.os.Environment
 import android.provider.OpenableColumns
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.PopupMenu
-import androidx.core.view.GravityCompat
-import androidx.core.view.isGone
+import androidx.core.view.*
 import androidx.fragment.app.FragmentTransaction
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -295,6 +294,20 @@ class MainActivity : AppCompatActivity(), MainNavigator, AnkoLogger {
         handleImplicitIntent(intent)
     }
 
+    override fun onStart() {
+        super.onStart()
+
+        if (getPrefBoolean(PrefConstants.HIDE_NAVIGATION_ON_SCROLL, false)) {
+            ViewCompat.setOnApplyWindowInsetsListener(nav) { _, insets ->
+                val systemInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+                nav.updatePadding(bottom = systemInsets.bottom)
+                insets
+            }
+        } else {
+            ViewCompat.setOnApplyWindowInsetsListener(nav, null)
+            nav.updatePadding(bottom = 0)
+        }
+    }
 
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)


### PR DESCRIPTION
When the navigation was transparent, the last item would be underneath the navigation and not clickable.

Below is a video of the fixed version:

![2020-09-17_03-42-02](https://user-images.githubusercontent.com/443370/93460299-da091580-f897-11ea-80f4-81ed48e87d13.gif)


