### PR TITLE
Fix issue with transparent navigation in landscape orientation

### DIFF
--- a/app/src/main/java/net/frju/flym/ui/entries/EntriesFragment.kt
+++ b/app/src/main/java/net/frju/flym/ui/entries/EntriesFragment.kt
@@ -24,9 +24,8 @@ import android.os.Bundle
 import android.os.Handler
 import android.util.TypedValue
 import android.view.*
+import android.widget.FrameLayout
 import androidx.appcompat.widget.SearchView
-import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.constraintlayout.widget.Guideline
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.os.bundleOf
@@ -43,8 +42,10 @@ import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.behavior.HideBottomViewOnScrollBehavior
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.snackbar.Snackbar
-import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.android.synthetic.main.fragment_entries.*
+import kotlinx.android.synthetic.main.fragment_entries.coordinator
+import kotlinx.android.synthetic.main.fragment_entries.refresh_layout
+import kotlinx.android.synthetic.main.fragment_entries.toolbar
 import kotlinx.android.synthetic.main.view_entry.view.*
 import net.fred.feedex.R
 import net.frju.flym.App
@@ -54,10 +55,7 @@ import net.frju.flym.data.utils.PrefConstants
 import net.frju.flym.service.FetcherService
 import net.frju.flym.ui.main.MainActivity
 import net.frju.flym.ui.main.MainNavigator
-import net.frju.flym.utils.closeKeyboard
-import net.frju.flym.utils.getPrefBoolean
-import net.frju.flym.utils.registerOnPrefChangeListener
-import net.frju.flym.utils.unregisterOnPrefChangeListener
+import net.frju.flym.utils.*
 import org.jetbrains.anko.*
 import org.jetbrains.anko.appcompat.v7.titleResource
 import org.jetbrains.anko.sdk21.listeners.onClick
@@ -339,41 +337,35 @@ class EntriesFragment : Fragment(R.layout.fragment_entries) {
             }
             ViewCompat.setOnApplyWindowInsetsListener(toolbar) { _, insets ->
                 val systemInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-                appbar.updateLayoutParams<CoordinatorLayout.LayoutParams> {
+                coordinator.updateLayoutParams<FrameLayout.LayoutParams> {
                     leftMargin = systemInsets.left
                     rightMargin = systemInsets.right
                 }
-                recycler_view.updatePadding(left = systemInsets.left, right = systemInsets.right, bottom = resources.getDimensionPixelSize(R.dimen.recycler_view_vertical_padding) + systemInsets.bottom)
+                recycler_view.updatePadding(bottom = resources.getDimensionPixelSize(R.dimen.recycler_view_vertical_padding) + systemInsets.bottom)
                 bottom_navigation.updatePadding(bottom = systemInsets.bottom)
                 bottom_navigation.updateLayoutParams<CoordinatorLayout.LayoutParams> {
                     height = resources.getDimensionPixelSize(R.dimen.bottom_nav_height) + systemInsets.bottom
-                    leftMargin = systemInsets.left
-                    rightMargin = systemInsets.right
                 }
                 toolbar.updateLayoutParams<AppBarLayout.LayoutParams> {
                     topMargin = systemInsets.top
                 }
-                activity?.drawer_header?.findViewById<Guideline>(R.id.guideline)?.updateLayoutParams<ConstraintLayout.LayoutParams> {
-                    guideBegin = systemInsets.top
-                }
                 insets
             }
-            activity?.window?.statusBarColor = ResourcesCompat.getColor(resources, R.color.status_bar_background, null)
-            activity?.window?.navigationBarColor = Color.TRANSPARENT
+            val statusBarBackground = ResourcesCompat.getColor(resources, R.color.status_bar_background, null)
+            activity?.window?.statusBarColor = statusBarBackground
+            activity?.window?.navigationBarColor = if (context?.isGestureNavigationEnabled() == true) Color.TRANSPARENT else statusBarBackground
         } else {
-            appbar.updateLayoutParams<CoordinatorLayout.LayoutParams> {
+            coordinator.updateLayoutParams<FrameLayout.LayoutParams> {
                 leftMargin = 0
                 rightMargin = 0
             }
-            recycler_view.updatePadding(left = 0, right = 0, bottom = resources.getDimensionPixelSize(R.dimen.recycler_view_bottom_padding_with_nav))
+            recycler_view.updatePadding(bottom = resources.getDimensionPixelSize(R.dimen.recycler_view_bottom_padding_with_nav))
             bottom_navigation.updateLayoutParams<CoordinatorLayout.LayoutParams> {
                 if (behavior is HideBottomViewOnScrollBehavior) {
                     (behavior as HideBottomViewOnScrollBehavior).slideUp(bottom_navigation)
                 }
                 behavior = null
                 height = resources.getDimensionPixelSize(R.dimen.bottom_nav_height)
-                leftMargin = 0
-                rightMargin = 0
             }
             bottom_navigation.updatePadding(bottom = 0)
             fabScrollListener?.let {
@@ -393,15 +385,12 @@ class EntriesFragment : Fragment(R.layout.fragment_entries) {
             activity?.window?.let {
                 WindowCompat.setDecorFitsSystemWindows(it, true)
             }
-            activity?.drawer_header?.findViewById<Guideline>(R.id.guideline)?.updateLayoutParams<ConstraintLayout.LayoutParams> {
-                guideBegin = 0
-            }
             ViewCompat.setOnApplyWindowInsetsListener(toolbar, null)
             val tv = TypedValue()
             if (activity?.theme?.resolveAttribute(R.attr.colorPrimaryDark, tv, true) == true) {
                 activity?.window?.statusBarColor = tv.data
+                activity?.window?.navigationBarColor = tv.data
             }
-            activity?.window?.navigationBarColor = Color.BLACK
         }
     }
 

--- a/app/src/main/java/net/frju/flym/ui/entrydetails/EntryDetailsActivity.kt
+++ b/app/src/main/java/net/frju/flym/ui/entrydetails/EntryDetailsActivity.kt
@@ -18,9 +18,12 @@
 package net.frju.flym.ui.entrydetails
 
 import android.os.Bundle
+import android.util.TypedValue
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
+import net.fred.feedex.R
 import net.frju.flym.utils.setupNoActionBarTheme
+import org.jetbrains.anko.backgroundColor
 
 class EntryDetailsActivity : AppCompatActivity() {
 
@@ -28,6 +31,11 @@ class EntryDetailsActivity : AppCompatActivity() {
         setupNoActionBarTheme()
 
         super.onCreate(savedInstanceState)
+
+        val tv = TypedValue()
+        if (theme.resolveAttribute(R.attr.colorPrimary, tv, true)) {
+            window.decorView.backgroundColor = tv.data
+        }
 
         if (savedInstanceState == null) {
             val fragment = EntryDetailsFragment().apply {

--- a/app/src/main/java/net/frju/flym/ui/entrydetails/EntryDetailsFragment.kt
+++ b/app/src/main/java/net/frju/flym/ui/entrydetails/EntryDetailsFragment.kt
@@ -24,13 +24,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.os.bundleOf
 import androidx.core.view.*
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.Observer
 import com.google.android.material.appbar.AppBarLayout
 import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.android.synthetic.main.fragment_entry_details.*
@@ -47,6 +45,7 @@ import net.frju.flym.data.utils.PrefConstants.HIDE_NAVIGATION_ON_SCROLL
 import net.frju.flym.service.FetcherService
 import net.frju.flym.ui.main.MainNavigator
 import net.frju.flym.utils.getPrefBoolean
+import net.frju.flym.utils.isGestureNavigationEnabled
 import net.frju.flym.utils.isOnline
 import org.jetbrains.anko.*
 import org.jetbrains.anko.support.v4.browse
@@ -163,21 +162,28 @@ class EntryDetailsFragment : Fragment() {
             }
             ViewCompat.setOnApplyWindowInsetsListener(toolbar) { _, insets ->
                 val systemInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-                app_bar_layout.updateLayoutParams<CoordinatorLayout.LayoutParams> {
-                    leftMargin = systemInsets.left
-                    rightMargin = systemInsets.right
+                if (swipe_view != null) {
+                    swipe_view.updateLayoutParams<FrameLayout.LayoutParams> {
+                        leftMargin = systemInsets.left
+                        rightMargin = systemInsets.right
+                    }
+                } else {
+                    coordinator.updateLayoutParams<FrameLayout.LayoutParams> {
+                        leftMargin = systemInsets.left
+                        rightMargin = systemInsets.right
+                    }
                 }
                 toolbar.updateLayoutParams<AppBarLayout.LayoutParams> {
                     topMargin = systemInsets.top
                 }
-                nested_scroll_view.updatePadding(left = systemInsets.left, right = systemInsets.right)
                 entry_view.updateLayoutParams<FrameLayout.LayoutParams> {
                     bottomMargin = systemInsets.bottom
                 }
                 insets
             }
-            activity?.window?.statusBarColor = ResourcesCompat.getColor(resources, R.color.status_bar_background, null)
-            activity?.window?.navigationBarColor = Color.TRANSPARENT
+            val statusBarBackground = ResourcesCompat.getColor(resources, R.color.status_bar_background, null)
+            activity?.window?.statusBarColor = statusBarBackground
+            activity?.window?.navigationBarColor = if (context?.isGestureNavigationEnabled() == true) Color.TRANSPARENT else statusBarBackground
         }
 
         setEntry(arguments?.getString(ARG_ENTRY_ID)!!, arguments?.getStringArrayList(ARG_ALL_ENTRIES_IDS)!!)

--- a/app/src/main/java/net/frju/flym/ui/main/MainActivity.kt
+++ b/app/src/main/java/net/frju/flym/ui/main/MainActivity.kt
@@ -30,7 +30,9 @@ import android.os.Environment
 import android.provider.OpenableColumns
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.PopupMenu
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.*
+import androidx.drawerlayout.widget.DrawerLayout
 import androidx.fragment.app.FragmentTransaction
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -301,11 +303,27 @@ class MainActivity : AppCompatActivity(), MainNavigator, AnkoLogger {
             ViewCompat.setOnApplyWindowInsetsListener(nav) { _, insets ->
                 val systemInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
                 nav.updatePadding(bottom = systemInsets.bottom)
+                drawer.updatePadding(left = systemInsets.left, right = systemInsets.right)
+                guideline.updateLayoutParams<ConstraintLayout.LayoutParams> {
+                    guideBegin = systemInsets.top
+                }
+                drawer_content.updatePadding(left = systemInsets.left)
+                drawer_content.updateLayoutParams<DrawerLayout.LayoutParams> {
+                    width = resources.getDimensionPixelSize(R.dimen.nav_drawer_width) + systemInsets.left
+                }
                 insets
             }
         } else {
             ViewCompat.setOnApplyWindowInsetsListener(nav, null)
             nav.updatePadding(bottom = 0)
+            drawer.updatePadding(left = 0, right = 0)
+            guideline.updateLayoutParams<ConstraintLayout.LayoutParams> {
+                guideBegin = 0
+            }
+            drawer_content.updatePadding(left = 0)
+            drawer_content.updateLayoutParams<DrawerLayout.LayoutParams> {
+                width = resources.getDimensionPixelSize(R.dimen.nav_drawer_width)
+            }
         }
     }
 

--- a/app/src/main/java/net/frju/flym/utils/ContextExtensions.kt
+++ b/app/src/main/java/net/frju/flym/utils/ContextExtensions.kt
@@ -20,6 +20,7 @@ package net.frju.flym.utils
 import android.app.AlertDialog
 import android.content.Context
 import android.content.SharedPreferences
+import android.provider.Settings
 import androidx.core.content.edit
 import org.jetbrains.anko.connectivityManager
 import org.jetbrains.anko.defaultSharedPreferences
@@ -85,4 +86,8 @@ fun Context.showAlertDialog(
             }
             .setNegativeButton(android.R.string.no, null)
             .show()
+}
+
+fun Context.isGestureNavigationEnabled(): Boolean {
+    return Settings.Secure.getInt(this.contentResolver, "navigation_mode", 0) == 2
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,14 +5,17 @@
     android:id="@+id/drawer"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:openDrawer="start">
+    tools:openDrawer="start"
+    android:background="?attr/colorPrimary">
 
     <net.frju.flym.ui.main.ContainersLayout
         android:id="@+id/containers_layout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:background="?attr/colorBackground" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/drawer_content"
         android:layout_width="@dimen/nav_drawer_width"
         android:layout_height="match_parent"
         android:layout_gravity="start"
@@ -23,6 +26,8 @@
         <include
             android:id="@+id/drawer_header"
             layout="@layout/view_main_drawer_header"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/fragment_entry_details.xml
+++ b/app/src/main/res/layout/fragment_entry_details.xml
@@ -4,7 +4,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/swipe_view"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="?attr/colorBackground">
 
     <ImageView
         android:id="@+id/navigate_before"

--- a/app/src/main/res/layout/fragment_entry_details_noswipe.xml
+++ b/app/src/main/res/layout/fragment_entry_details_noswipe.xml
@@ -4,7 +4,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/coordinator"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="?attr/colorBackground">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar_layout"

--- a/app/src/main/res/layout/view_main_drawer_header.xml
+++ b/app/src/main/res/layout/view_main_drawer_header.xml
@@ -5,7 +5,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@color/colorPrimary"
-    android:minHeight="136dp"
     android:theme="@style/ThemeOverlay.AppCompat.Dark">
 
     <ImageView
@@ -29,14 +28,12 @@
     <TextView
         android:id="@+id/drawer_hint"
         android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginStart="24dp"
-        android:layout_marginTop="24dp"
-        android:layout_marginEnd="96dp"
-        android:layout_marginBottom="24dp"
+        android:layout_height="wrap_content"
+        android:paddingStart="24dp"
+        android:paddingEnd="80dp"
+        android:paddingVertical="24dp"
         android:gravity="bottom"
         android:text="@string/drawer_explanation"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@id/guideline" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -7,7 +7,7 @@
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
         <item name="colorBackground">@color/colorBackground</item>
-        <item name="android:windowBackground">@color/colorBackground</item>
+        <item name="android:windowBackground">?attr/colorBackground</item>
         <item name="colorReadState">@color/read_state</item>
         <item name="colorColoredReadState">@color/colored_read_state</item>
         <item name="colorQuoteBackground">@color/quote_background_dark</item>
@@ -15,6 +15,7 @@
         <item name="colorArticleText">@color/article_text_dark</item>
         <item name="colorSubtitle">@color/subtitle_dark</item>
         <item name="colorSubtitleBorder">@color/subtitle_border_dark</item>
+        <item name="android:navigationBarColor">?attr/colorPrimaryDark</item>
     </style>
 
     <style name="AppTheme.ActionBar" parent="Theme.AppCompat">
@@ -37,7 +38,7 @@
         <item name="colorPrimaryDark">@color/colorPrimaryLight</item>
         <item name="colorAccent">@color/colorAccent</item>
         <item name="colorBackground">@color/colorBackgroundLight</item>
-        <item name="android:windowBackground">@color/colorBackgroundLight</item>
+        <item name="android:windowBackground">?attr/colorBackground</item>
         <item name="colorReadState">@color/read_state_light</item>
         <item name="colorColoredReadState">@color/colored_read_state_light</item>
         <item name="colorQuoteBackground">@color/quote_background_light</item>
@@ -45,6 +46,7 @@
         <item name="colorArticleText">@color/article_text_light</item>
         <item name="colorSubtitle">@color/subtitle_light</item>
         <item name="colorSubtitleBorder">@color/subtitle_border_light</item>
+        <item name="android:navigationBarColor">?attr/colorPrimaryDark</item>
     </style>
 
     <style name="AppThemeLight.ActionBar" parent="Theme.AppCompat.Light.DarkActionBar">
@@ -67,7 +69,7 @@
         <item name="colorPrimaryDark">@color/colorPrimaryDarkBlack</item>
         <item name="colorAccent">@color/colorAccentBlack</item>
         <item name="colorBackground">@color/colorBackgroundBlack</item>
-        <item name="android:windowBackground">@color/colorBackgroundBlack</item>
+        <item name="android:windowBackground">?attr/colorBackground</item>
         <item name="colorReadState">@color/read_state_black</item>
         <item name="colorColoredReadState">@color/colored_read_state_black</item>
         <item name="colorQuoteBackground">@color/quote_background_black</item>
@@ -75,7 +77,7 @@
         <item name="colorArticleText">@color/article_text_black</item>
         <item name="colorSubtitle">@color/subtitle_black</item>
         <item name="colorSubtitleBorder">@color/subtitle_border_black</item>
-
+        <item name="android:navigationBarColor">?attr/colorPrimaryDark</item>
     </style>
 
     <style name="AppThemeBlack.ActionBar" parent="Theme.AppCompat">


### PR DESCRIPTION
The transparent nav when in landscape orientation was causing all sorts of elements to render underneath the nav. The drawer now properly offsets as well as the SwipeRefreshLayout refreshing indicator bar. Also cleaned up some code and got the drawer header to render at the correct height with/without transparent status bar.

Also added support for coloring the navigation bar the same as the status bar in this PR.

Sorry I didn't handle these cases in my older PRs, I normally use gesture navigation which doesn't have these problems. 😅

Depends on https://github.com/FredJul/Flym/pull/670

Also fixes https://github.com/FredJul/Flym/issues/674

![2020-09-17_14-50-43](https://user-images.githubusercontent.com/443370/93532225-76153a00-f8f5-11ea-9e64-d0445fee1c3d.gif)