### PR TITLE
Update discover fragment to color based on theme

### DIFF
--- a/app/src/main/java/net/frju/flym/ui/discover/DiscoverActivity.kt
+++ b/app/src/main/java/net/frju/flym/ui/discover/DiscoverActivity.kt
@@ -13,6 +13,7 @@ import net.fred.feedex.R
 import net.frju.flym.App
 import net.frju.flym.data.entities.Feed
 import net.frju.flym.data.entities.SearchFeedResult
+import net.frju.flym.utils.setupTheme
 import org.jetbrains.anko.design.snackbar
 import org.jetbrains.anko.doAsync
 import org.jetbrains.anko.sdk21.listeners.onClick
@@ -39,6 +40,7 @@ class DiscoverActivity : AppCompatActivity(), FeedManagementInterface {
     private var searchInput: AutoCompleteTextView? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        setupTheme()
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_feed_search)
         this.initSearchInputs()

--- a/app/src/main/res/layout/activity_feed_search.xml
+++ b/app/src/main/res/layout/activity_feed_search.xml
@@ -30,7 +30,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:src="@drawable/ic_search_white_24dp"
-        android:tint="@color/colorPrimary"
+        android:tint="?attr/colorAccent"
         app:layout_constraintBottom_toTopOf="@id/fcv_discover_fragments"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_chainStyle="spread"

--- a/app/src/main/res/layout/item_feed_search_result.xml
+++ b/app/src/main/res/layout/item_feed_search_result.xml
@@ -43,15 +43,17 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_margin="2dp"
-            android:textColor="@android:color/white"
-            android:textSize="16sp" />
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:textColor="?attr/colorReadState" />
 
         <TextView
             android:id="@+id/tv_description"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_margin="2dp"
-            android:textSize="12sp" />
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:textColor="?attr/colorReadState" />
+
     </LinearLayout>
 
     <ImageView
@@ -61,6 +63,7 @@
         android:layout_marginEnd="8dp"
         android:src="@drawable/ic_baseline_add_24"
         android:visibility="visible"
+        app:tint="?attr/colorReadState"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintLeft_toRightOf="@+id/ll_details"


### PR DESCRIPTION
Fixes discover fragment to color correctly based on theme and works in all 3 different themes.

![2020-09-17_16-48-07](https://user-images.githubusercontent.com/443370/93539518-e035db00-f905-11ea-926b-64ce0a13e1e4.gif)
