### PR TITLE
Fix crash when rotating device on Discover Fragment

### DIFF
--- a/app/src/main/java/net/frju/flym/ui/discover/DiscoverActivity.kt
+++ b/app/src/main/java/net/frju/flym/ui/discover/DiscoverActivity.kt
@@ -42,9 +42,18 @@ class DiscoverActivity : AppCompatActivity(), FeedManagementInterface {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_feed_search)
         this.initSearchInputs()
-        this.goDiscover()
 
-        intent.getStringExtra(FeedSearchFragment.ARG_QUERY)?.let { searchForFeed(it) }
+        val query = savedInstanceState?.getString(FeedSearchFragment.ARG_QUERY) ?: intent.getStringExtra(FeedSearchFragment.ARG_QUERY)
+        if (!query.isNullOrEmpty()) {
+            this.searchForFeed(query)
+        } else {
+            this.goDiscover()
+        }
+    }
+
+    override fun onSaveInstanceState(savedInstanceState: Bundle) {
+        super.onSaveInstanceState(savedInstanceState)
+        savedInstanceState.putString(FeedSearchFragment.ARG_QUERY, searchInput?.text?.toString())
     }
 
     private fun initSearchInputs() {


### PR DESCRIPTION
Also prevents the grid animation from playing every time the device is rotated.

![2020-09-17_17-33-15](https://user-images.githubusercontent.com/443370/93541670-e929ab00-f90b-11ea-99b5-5c7b4ae99b39.gif)
