### PR TITLE
Make read timeout configurable

### DIFF
--- a/app/src/main/java/net/frju/flym/data/utils/PrefConstants.kt
+++ b/app/src/main/java/net/frju/flym/data/utils/PrefConstants.kt
@@ -53,4 +53,6 @@ object PrefConstants {
     const val SORT_ORDER = "sort_order"
 
     const val ENABLE_SWIPE_ENTRY = "enable_swipe_entry"
+
+    const val READ_TIMEOUT = "read_timeout"
 }

--- a/app/src/main/java/net/frju/flym/service/FetcherService.kt
+++ b/app/src/main/java/net/frju/flym/service/FetcherService.kt
@@ -83,7 +83,6 @@ class FetcherService : IntentService(FetcherService::class.java.simpleName) {
 
         private val HTTP_CLIENT: OkHttpClient = OkHttpClient.Builder()
                 .connectTimeout(10, TimeUnit.SECONDS)
-                .readTimeout(10, TimeUnit.SECONDS)
                 .cookieJar(JavaNetCookieJar(COOKIE_MANAGER))
                 .build()
 
@@ -101,11 +100,15 @@ class FetcherService : IntentService(FetcherService::class.java.simpleName) {
         private const val TEMP_PREFIX = "TEMP__"
         private const val ID_SEPARATOR = "__"
 
-        fun createCall(url: String): Call = HTTP_CLIENT.newCall(Request.Builder()
-                .url(url)
-                .header("User-agent", "Mozilla/5.0 (compatible) AppleWebKit Chrome Safari") // some feeds need this to work properly
-                .addHeader("accept", "*/*")
-                .build())
+        fun createCall(url: String): Call = HTTP_CLIENT.newBuilder()
+                .readTimeout(App.context.getPrefString(PrefConstants.READ_TIMEOUT, "10")?.toLongOrNull() ?: 10, TimeUnit.SECONDS)
+                .build()
+                .newCall(Request.Builder()
+                        .url(url)
+                        .header("User-agent", "Mozilla/5.0 (compatible) AppleWebKit Chrome Safari") // some feeds need this to work properly
+                        .addHeader("accept", "*/*")
+                        .build()
+                )
 
         fun fetch(context: Context, isFromAutoRefresh: Boolean, action: String, feedId: Long = 0L) {
             if (context.getPrefBoolean(PrefConstants.IS_REFRESHING, false)) {

--- a/app/src/main/java/net/frju/flym/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/net/frju/flym/ui/settings/SettingsFragment.kt
@@ -18,10 +18,14 @@
 package net.frju.flym.ui.settings
 
 import android.os.Bundle
+import android.text.InputType
+import android.widget.EditText
 import androidx.preference.CheckBoxPreference
+import androidx.preference.EditTextPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import net.fred.feedex.R
+import net.frju.flym.data.utils.PrefConstants.READ_TIMEOUT
 import net.frju.flym.data.utils.PrefConstants.REFRESH_ENABLED
 import net.frju.flym.data.utils.PrefConstants.REFRESH_INTERVAL
 import net.frju.flym.data.utils.PrefConstants.THEME
@@ -50,5 +54,9 @@ class SettingsFragment : PreferenceFragmentCompat() {
                     startActivity<MainActivity>()
                     true
                 }
+        
+        findPreference<EditTextPreference>(READ_TIMEOUT)?.setOnBindEditTextListener { editText: EditText ->
+            editText.setRawInputType(InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_VARIATION_NORMAL);
+        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -172,4 +172,7 @@
         <item>Dark</item>
         <item>Black</item>
     </string-array>
+    <string name="settings_category_timeout">Timeouts</string>
+    <string name="settings_read_timeout">Read Timeout</string>
+    <string name="settings_read_timeout_description">Number of seconds to wait for additional data to come int before giving up</string>
 </resources>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -193,5 +193,16 @@
             android:title="@string/filter_title" />
 
     </PreferenceCategory>
+    <PreferenceCategory
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:title="@string/settings_category_timeout">
+
+        <EditTextPreference
+            android:defaultValue="10"
+            android:key="read_timeout"
+            android:summary="@string/settings_read_timeout_description"
+            android:title="@string/settings_read_timeout" />
+    </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
Related to #419.

Alternately, we could try setting a timeout for the entire connection rather than "going 10 seconds without recieving any data", or provide more timeout options, etc. This is just my first stab at it.

Also not quite sure about the wording I used for the new setting, so feel free to have me tweak that.

I've tested to ensure it works in the Android Emulator by connecting to a server that will never respond (`nc -l 8000`, add feed at `http://<host-ip>:8000` by adding another random feed and editing the URL)

(btw this is my first contribution to an Android App, so i recommend you make sure I didn't miss something)