### PR TITLE
Fix star tint on entry list

### DIFF
--- a/app/src/main/java/net/frju/flym/ui/entries/EntryAdapter.kt
+++ b/app/src/main/java/net/frju/flym/ui/entries/EntryAdapter.kt
@@ -81,6 +81,7 @@ class EntryAdapter(var displayThumbnails: Boolean, private val globalClickListen
             date.isEnabled = !entryWithFeed.entry.read
             date.text = entryWithFeed.entry.getReadablePublicationDate(context)
 
+            favorite_icon.isEnabled = !entryWithFeed.entry.read
             if (entryWithFeed.entry.favorite) {
                 favorite_icon.setImageResource(R.drawable.ic_star_24dp)
             } else {

--- a/app/src/main/res/drawable/ic_star_24dp.xml
+++ b/app/src/main/res/drawable/ic_star_24dp.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="24.0"
     android:viewportHeight="24.0">
     <path
-        android:fillColor="?attr/colorReadState"
+        android:fillColor="@android:color/white"
         android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z" />
 </vector>

--- a/app/src/main/res/drawable/ic_star_border_24dp.xml
+++ b/app/src/main/res/drawable/ic_star_border_24dp.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="24.0"
     android:viewportHeight="24.0">
     <path
-        android:fillColor="?attr/colorReadState"
+        android:fillColor="@android:color/white"
         android:pathData="M22,9.24l-7.19,-0.62L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21 12,17.27 18.18,21l-1.63,-7.03L22,9.24zM12,15.4l-3.76,2.27 1,-4.28 -3.32,-2.88 4.38,-0.38L12,6.1l1.71,4.04 4.38,0.38 -3.32,2.88 1,4.28L12,15.4z" />
 </vector>

--- a/app/src/main/res/layout/view_entry.xml
+++ b/app/src/main/res/layout/view_entry.xml
@@ -22,7 +22,6 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-
     <TextView
         android:id="@+id/title"
         android:layout_width="0dp"
@@ -78,7 +77,6 @@
         app:layout_constraintTop_toTopOf="@+id/feed_name_layout"
         tools:text="24/12/2006 12:45" />
 
-
     <ImageView
         android:id="@+id/favorite_icon"
         android:layout_width="wrap_content"
@@ -86,6 +84,7 @@
         android:padding="12dp"
         android:src="@drawable/ic_star_24dp"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:tint="?attr/colorReadState" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
The star will now properly tint based on read/unread status in entries list.

![2020-09-21_22-53-02](https://user-images.githubusercontent.com/443370/93847987-549db080-fc5d-11ea-93d6-2dcbb78bc5e0.png)
