### PR TITLE
Enable strict mode and fix perf issues

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     implementation "org.jetbrains.anko:anko-appcompat-v7:$anko_version"
     implementation "org.jetbrains.anko:anko-design:$anko_version"
 
-    def okhttp_version = '4.8.1'
+    def okhttp_version = '4.9.0'
     implementation "com.squareup.okhttp3:okhttp:$okhttp_version"
     implementation "com.squareup.okhttp3:okhttp-urlconnection:$okhttp_version"
 
@@ -109,7 +109,7 @@ dependencies {
     implementation "com.github.bumptech.glide:glide:$glide_version"
     kapt "com.github.bumptech.glide:compiler:$glide_version"
 
-    implementation 'androidx.core:core-ktx:1.5.0-alpha02'
+    implementation 'androidx.core:core-ktx:1.5.0-alpha03'
     implementation 'androidx.paging:paging-runtime:2.1.2'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.1'
     implementation 'androidx.preference:preference:1.1.1'

--- a/app/src/main/java/net/frju/flym/App.kt
+++ b/app/src/main/java/net/frju/flym/App.kt
@@ -20,9 +20,16 @@ package net.frju.flym
 import android.annotation.SuppressLint
 import android.app.Application
 import android.content.Context
+import android.os.Build
+import android.os.StrictMode
+import android.os.StrictMode.VmPolicy
+import android.os.strictmode.UntaggedSocketViolation
+import android.util.Log
+import net.fred.feedex.BuildConfig
 import net.frju.flym.data.AppDatabase
 import net.frju.flym.data.utils.PrefConstants
 import net.frju.flym.utils.putPrefBoolean
+import java.util.concurrent.Executors
 
 
 class App : Application() {
@@ -45,5 +52,26 @@ class App : Application() {
         db = AppDatabase.createDatabase(context)
 
         context.putPrefBoolean(PrefConstants.IS_REFRESHING, false) // init
+
+        // Enable strict mode to find performance issues in debug build
+        if (BuildConfig.DEBUG) {
+            StrictMode.setThreadPolicy(StrictMode.ThreadPolicy.Builder()
+                    .detectAll()
+                    .penaltyLog()
+                    .penaltyFlashScreen()
+                    .build())
+            val vmPolicy = VmPolicy.Builder().detectAll()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                vmPolicy.penaltyListener(Executors.newSingleThreadExecutor(), {
+                    // Hide UntaggedSocketViolations since they are useless and unfixable in okhttp and glide
+                    if (it !is UntaggedSocketViolation) {
+                        Log.d("StrictMode", "StrictMode policy violation: " + it.stackTrace)
+                    }
+                })
+            } else {
+                vmPolicy.penaltyLog()
+            }
+            StrictMode.setVmPolicy(vmPolicy.build())
+        }
     }
 }

--- a/app/src/main/java/net/frju/flym/utils/ActivityExtensions.kt
+++ b/app/src/main/java/net/frju/flym/utils/ActivityExtensions.kt
@@ -20,7 +20,9 @@ package net.frju.flym.utils
 import android.app.Activity
 import net.fred.feedex.R
 import net.frju.flym.data.utils.PrefConstants
+import org.jetbrains.anko.doAsync
 import org.jetbrains.anko.inputMethodManager
+import org.jetbrains.anko.uiThread
 
 fun Activity.closeKeyboard() {
     currentFocus?.let {
@@ -29,17 +31,21 @@ fun Activity.closeKeyboard() {
 }
 
 fun Activity.setupTheme() {
-    setTheme(when (getPrefString(PrefConstants.THEME, "DARK")) {
-        "LIGHT" -> R.style.AppThemeLight
-        "BLACK" -> R.style.AppThemeBlack
-        else -> R.style.AppTheme
-    })
+    doAsync {
+        setTheme(when (getPrefString(PrefConstants.THEME, "DARK")) {
+            "LIGHT" -> R.style.AppThemeLight
+            "BLACK" -> R.style.AppThemeBlack
+            else -> R.style.AppTheme
+        })
+    }
 }
 
 fun Activity.setupNoActionBarTheme() {
-    setTheme(when (getPrefString(PrefConstants.THEME, "DARK")) {
-        "LIGHT" -> R.style.AppThemeLight_NoActionBar
-        "BLACK" -> R.style.AppThemeBlack_NoActionBar
-        else -> R.style.AppTheme_NoActionBar
-    })
+    doAsync {
+        setTheme(when (getPrefString(PrefConstants.THEME, "DARK")) {
+            "LIGHT" -> R.style.AppThemeLight_NoActionBar
+            "BLACK" -> R.style.AppThemeBlack_NoActionBar
+            else -> R.style.AppTheme_NoActionBar
+        })
+    }
 }


### PR DESCRIPTION
Strict mode allows you to see when stuff is running on UI thread that is long running (and various other issues that are related). This enables that and then fixes the major perf issues that were obvious once strict mode was turned on. All of the issues fixed are centered around trying to run disk reads off UI thread. This should dramatically reduce frame drops when scrolling on entries fragment.

I also ignore UntaggedSocketViolations since they are useless and will never be fixed in okhttp/glide

I tried testing as much of the app as I could to make sure switching these parts of the code to `doAsync { ... }` doesn't break anything, but a second set of eyes to make sure everything is still working would be great. 😃

before (red flashes are frame drops):
![2020-09-22_15-09-44](https://user-images.githubusercontent.com/443370/93942706-ce797c80-fce5-11ea-8328-2916298ab33f.gif)

after (no red flashes, no frame drops):
![2020-09-22_15-10-29](https://user-images.githubusercontent.com/443370/93942714-d20d0380-fce5-11ea-87a8-000c942cbd58.gif)