### PR TITLE
For #580: Fix unread badge background and text colors

### DIFF
--- a/app/src/main/java/net/frju/flym/ui/entries/EntriesFragment.kt
+++ b/app/src/main/java/net/frju/flym/ui/entries/EntriesFragment.kt
@@ -176,7 +176,8 @@ class EntriesFragment : Fragment(R.layout.fragment_entries) {
         unreadBadge = QBadgeView(context).bindTarget((bottom_navigation.getChildAt(0) as ViewGroup).getChildAt(0)).apply {
             setGravityOffset(35F, 0F, true)
             isShowShadow = false
-            badgeBackgroundColor = requireContext().colorAttr(R.attr.colorAccent)
+            badgeBackgroundColor = requireContext().colorAttr(R.attr.colorUnreadBadgeBackground)
+            badgeTextColor = requireContext().colorAttr(R.attr.colorUnreadBadgeText)
         }
 
         read_all_fab.onClick { _ ->

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -8,4 +8,6 @@
     <attr name="colorArticleText" format="reference" />
     <attr name="colorSubtitle" format="reference" />
     <attr name="colorSubtitleBorder" format="reference" />
+    <attr name="colorUnreadBadgeBackground" format="reference" />
+    <attr name="colorUnreadBadgeText" format="reference" />
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -16,6 +16,8 @@
         <item name="colorSubtitle">@color/subtitle_dark</item>
         <item name="colorSubtitleBorder">@color/subtitle_border_dark</item>
         <item name="android:navigationBarColor">?attr/colorPrimaryDark</item>
+        <item name="colorUnreadBadgeBackground">@color/colorPrimaryDark</item>
+        <item name="colorUnreadBadgeText">@color/color_unread_black</item>
     </style>
 
     <style name="AppTheme.ActionBar" parent="Theme.AppCompat">
@@ -47,6 +49,8 @@
         <item name="colorSubtitle">@color/subtitle_light</item>
         <item name="colorSubtitleBorder">@color/subtitle_border_light</item>
         <item name="android:navigationBarColor">?attr/colorPrimaryDark</item>
+        <item name="colorUnreadBadgeBackground">@color/colorPrimaryDark</item>
+        <item name="colorUnreadBadgeText">@color/color_unread</item>
     </style>
 
     <style name="AppThemeLight.ActionBar" parent="Theme.AppCompat.Light.DarkActionBar">
@@ -78,6 +82,8 @@
         <item name="colorSubtitle">@color/subtitle_black</item>
         <item name="colorSubtitleBorder">@color/subtitle_border_black</item>
         <item name="android:navigationBarColor">?attr/colorPrimaryDark</item>
+        <item name="colorUnreadBadgeBackground">@color/colorAccentBlack</item>
+        <item name="colorUnreadBadgeText">@color/colorBackgroundBlack</item>
     </style>
 
     <style name="AppThemeBlack.ActionBar" parent="Theme.AppCompat">


### PR DESCRIPTION
Fixes #580.
Also adjusts the text color so that the color combination of text and background pass the ![WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/).

### Screenshots
|Light|Dark|Black|
|------|-------|-------|
<img src="https://user-images.githubusercontent.com/46764284/94481620-4d841e80-01d8-11eb-8076-36e66906fbf9.png" width=300 />|<img src="https://user-images.githubusercontent.com/46764284/94481678-655ba280-01d8-11eb-94ab-98519d42d02e.png" width=300 />|<img src="https://user-images.githubusercontent.com/46764284/94481791-98059b00-01d8-11eb-8e48-7b58e38d616e.png" width=300 />|
