### PR TITLE
For #692: Reorder settings into more logical groups

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,23 +101,22 @@
     <string name="settings_refresh_enable_notifications">Display refresh notifications</string>
     <string name="settings_refresh_enable_notifications_description">Show a system notification when a refresh is completed</string>
     <string name="settings_refresh_interval">Refresh interval</string>
-    <string name="settings_category_keep_time">Time to keep entries</string>
     <string name="settings_keep_time">Time that read entries will be kept</string>
     <string name="settings_keep_time_unread">Time that unread entries will be kept</string>
-    <string name="settings_category_content_presentation">Content presentation</string>
+    <string name="settings_category_general">General</string>
     <string name="settings_display_thumbnails">Display thumbnails</string>
-    <string name="settings_display_thumbnails_description">Display thumbnails in feed</string>
+    <string name="settings_display_thumbnails_description">Display thumbnails in the article list</string>
     <string name="settings_display_images">Display images</string>
     <string name="settings_display_images_description">Display images in entries</string>
     <string name="settings_preload_image_mode">Preload images</string>
     <string name="settings_font_size">Text size</string>
     <string name="settings_refresh_wifi_only">Refresh only over Wi-Fi</string>
     <string name="settings_refresh_wifi_only_description">Automatic refresh will only be done if a Wi-Fi connection is available</string>
-    <string name="settings_category_filter">Filters</string>
     <string name="settings_remove_duplicates_description_title">Remove duplicates</string>
     <string name="settings_remove_duplicates_description">Checks the title of newly-downloaded items and skips when one with the same title is already present</string>
-    <string name="filter">Remove items containing keywords (comma-separated list)</string>
-    <string name="filter_title">Blacklist</string>
+    <string name="filter">Remove items containing keywords</string>
+    <string name="filter_title">Blocklist</string>
+    <string name="filter_dialog_message">Separate keywords with commas</string>
     <string name="settings_theme">Theme</string>
     <string name="open_browser_direct">Open entries directly in your default browser</string>
     <string name="open_browser_direct_title">Open in browser</string>
@@ -130,8 +129,9 @@
     <string name="settings_sort_order">Sort entries from newest to oldest</string>
     <string name="settings_sort_order_title">Sort order</string>
     <string name="settings_enable_entry_swipe">Enable swipe while viewing an entry</string>
-
-    <string name="settings_enable_entry_swipe_description">If enabled, allows swiping between entries while viewing an entry.</string>
+    <string name="settings_category_article_list">Article list</string>
+    <string name="settings_category_article_appearance">Article appearance</string>
+    <string name="settings_enable_entry_swipe_description">If enabled, allows swiping between entries while viewing an entry</string>
 
     <string-array name="settings_intervals">
         <item>5 minutes</item>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -6,7 +6,7 @@
     <PreferenceCategory
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:title="@string/settings_category_content_presentation">
+        android:title="@string/settings_category_general">
 
         <net.frju.flym.ui.views.AutoSummaryListPreference
             android:layout_width="wrap_content"
@@ -18,6 +18,22 @@
             android:key="theme"
             android:title="@string/settings_theme" />
 
+        <CheckBoxPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="false"
+            android:key="hide_navigation_on_scroll"
+            android:summary="@string/settings_hide_navigation_on_scroll_description"
+            android:title="@string/settings_hide_navigation_on_scroll" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:title="@string/settings_category_article_appearance">
+
+
         <net.frju.flym.ui.views.AutoSummaryListPreference
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -27,14 +43,6 @@
             android:inputType="number"
             android:key="font_size"
             android:title="@string/settings_font_size" />
-
-        <CheckBoxPreference
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:defaultValue="true"
-            android:key="display_thumbnails"
-            android:summary="@string/settings_display_thumbnails_description"
-            android:title="@string/settings_display_thumbnails" />
 
         <CheckBoxPreference
             android:layout_width="wrap_content"
@@ -66,18 +74,34 @@
         <CheckBoxPreference
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:defaultValue="false"
-            android:key="hide_button_mark_all_as_read"
-            android:summary="@string/settings_hide_button_mark_all_as_read_description"
-            android:title="@string/settings_hide_button_mark_all_as_read" />
+            android:defaultValue="true"
+            android:key="enable_swipe_entry"
+            android:summary="@string/settings_enable_entry_swipe_description"
+            android:title="@string/settings_enable_entry_swipe" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:title="@string/settings_category_article_list">
+
+
+        <CheckBoxPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="true"
+            android:key="display_thumbnails"
+            android:summary="@string/settings_display_thumbnails_description"
+            android:title="@string/settings_display_thumbnails" />
 
         <CheckBoxPreference
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:defaultValue="false"
-            android:key="hide_navigation_on_scroll"
-            android:summary="@string/settings_hide_navigation_on_scroll_description"
-            android:title="@string/settings_hide_navigation_on_scroll" />
+            android:key="hide_button_mark_all_as_read"
+            android:summary="@string/settings_hide_button_mark_all_as_read_description"
+            android:title="@string/settings_hide_button_mark_all_as_read" />
 
         <CheckBoxPreference
             android:layout_width="wrap_content"
@@ -87,13 +111,40 @@
             android:summary="@string/settings_sort_order"
             android:title="@string/settings_sort_order_title" />
 
+        <net.frju.flym.ui.views.AutoSummaryListPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="4"
+            android:entries="@array/settings_keep_times"
+            android:entryValues="@array/settings_keep_time_values"
+            android:inputType="number"
+            android:key="keep_time"
+            android:title="@string/settings_keep_time" />
+
+        <net.frju.flym.ui.views.AutoSummaryListPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="0"
+            android:entries="@array/settings_keep_times"
+            android:entryValues="@array/settings_keep_time_values"
+            android:inputType="number"
+            android:key="keep_time_unread"
+            android:title="@string/settings_keep_time_unread" />
+
         <CheckBoxPreference
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:defaultValue="true"
-            android:key="enable_swipe_entry"
-            android:summary="@string/settings_enable_entry_swipe_description"
-            android:title="@string/settings_enable_entry_swipe" />
+            android:key="remove_duplicates"
+            android:summary="@string/settings_remove_duplicates_description"
+            android:title="@string/settings_remove_duplicates_description_title" />
+
+        <EditTextPreference
+            android:key="filter_keywords"
+            android:summary="@string/filter"
+            android:title="@string/filter_title"
+            android:dialogMessage="@string/filter_dialog_message"/>
+
 
     </PreferenceCategory>
 
@@ -145,52 +196,6 @@
             android:key="refresh_wifi_only"
             android:summary="@string/settings_refresh_wifi_only_description"
             android:title="@string/settings_refresh_wifi_only" />
-
-    </PreferenceCategory>
-
-    <PreferenceCategory
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:title="@string/settings_category_keep_time">
-
-        <net.frju.flym.ui.views.AutoSummaryListPreference
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:defaultValue="4"
-            android:entries="@array/settings_keep_times"
-            android:entryValues="@array/settings_keep_time_values"
-            android:inputType="number"
-            android:key="keep_time"
-            android:title="@string/settings_keep_time" />
-
-        <net.frju.flym.ui.views.AutoSummaryListPreference
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:defaultValue="0"
-            android:entries="@array/settings_keep_times"
-            android:entryValues="@array/settings_keep_time_values"
-            android:inputType="number"
-            android:key="keep_time_unread"
-            android:title="@string/settings_keep_time_unread" />
-    </PreferenceCategory>
-
-    <PreferenceCategory
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:title="@string/settings_category_filter">
-
-        <CheckBoxPreference
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:defaultValue="true"
-            android:key="remove_duplicates"
-            android:summary="@string/settings_remove_duplicates_description"
-            android:title="@string/settings_remove_duplicates_description_title" />
-
-        <EditTextPreference
-            android:key="filter_keywords"
-            android:summary="@string/filter"
-            android:title="@string/filter_title" />
 
     </PreferenceCategory>
 


### PR DESCRIPTION
Addresses #692.

Also:
- Changes "Blacklist" to "Blocklist" (see ![here](https://www.adexchanger.com/data-driven-thinking/no-more-inflammatory-jargon-change-blacklist-to-blocklist/) for details).
- Adds explanatory text to the blocklist dialog, so the users sees that keywords have to be comma-separated when they are actually typing them into the field, not before.
- Removes a period `.` in `settings_enable_entry_swipe_description` to be consistent with all other settings descriptions.