### PR TITLE
For #422: Add contentDescriptions for accessibility

### DIFF
--- a/app/src/main/java/net/frju/flym/ui/entries/EntriesFragment.kt
+++ b/app/src/main/java/net/frju/flym/ui/entries/EntriesFragment.kt
@@ -171,6 +171,7 @@ class EntriesFragment : Fragment(R.layout.fragment_entries) {
 
         (activity as MainActivity).setSupportActionBar(toolbar)
         toolbar.setNavigationIcon(R.drawable.ic_menu_24dp)
+        toolbar.setNavigationContentDescription(R.string.navigation_button_content_description)
         toolbar.setNavigationOnClickListener { (activity as MainActivity).toggleDrawer() }
 
         unreadBadge = QBadgeView(context).bindTarget((bottom_navigation.getChildAt(0) as ViewGroup).getChildAt(0)).apply {

--- a/app/src/main/java/net/frju/flym/ui/feeds/BaseFeedAdapter.kt
+++ b/app/src/main/java/net/frju/flym/ui/feeds/BaseFeedAdapter.kt
@@ -110,12 +110,14 @@ abstract class BaseFeedAdapter(groups: List<FeedGroup>) : ExpandableRecyclerAdap
                                 "LIGHT" -> R.drawable.ic_keyboard_arrow_up_black_24dp
                                 else -> R.drawable.ic_keyboard_arrow_up_white_24dp
                             })
+                    itemView.icon.contentDescription = R.string.collapse_arrow_content_description.toString()
                 } else {
                     itemView.icon.setImageResource(
                             when (itemView.context.getPrefString(PrefConstants.THEME, "DARK")) {
                                 "LIGHT" -> R.drawable.ic_keyboard_arrow_down_black_24dp
                                 else -> R.drawable.ic_keyboard_arrow_down_white_24dp
                             })
+                    itemView.icon.contentDescription = R.string.expand_arrow_content_description.toString()
                 }
 
                 itemView.icon.isClickable = true

--- a/app/src/main/res/layout/fragment_entries.xml
+++ b/app/src/main/res/layout/fragment_entries.xml
@@ -55,7 +55,8 @@
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="16dp"
         android:src="@drawable/ic_read_all_white_24dp"
-        app:layout_dodgeInsetEdges="bottom" />
+        app:layout_dodgeInsetEdges="bottom"
+        android:contentDescription="@string/mark_all_as_read_fab_content_description" />
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottom_navigation"

--- a/app/src/main/res/layout/view_feed_edit.xml
+++ b/app/src/main/res/layout/view_feed_edit.xml
@@ -15,7 +15,8 @@
         android:scaleType="center"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        android:contentDescription="@string/feed_edit_feed_icon_content_description" />
 
     <TextView
         android:id="@+id/title"
@@ -40,6 +41,7 @@
         android:src="@drawable/ic_drag_handle_white_24dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        android:contentDescription="@string/feed_edit_drag_handle_content_description" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,7 @@
     <string name="drawer_explanation">Welcome!\n\nLong press on the feeds to see options ▼</string>
     <string name="drawer_fetch_error_explanation">Some of your feeds did not refresh correctly ▼</string>
     <string name="about_screen_info">I\'m publishing this application as free and open-source software under GPLv3 licence. Feel free to modify it as long as you keep it open-source as well.</string>
+    <string name="navigation_button_content_description">Toggle feed menu</string>
 
     <!-- FEEDS -->
     <string name="feeds">Feeds</string>
@@ -44,6 +45,8 @@
     <string name="to_group_above">Above the group</string>
     <string name="to_group_into">Into the group</string>
     <string name="feed_name">Feed name</string>
+    <string name="feed_edit_drag_handle_content_description">Drag handle</string>
+    <string name="feed_edit_feed_icon_content_description">Feed icon</string>
 
     <!-- ENTRIES -->
     <string name="feed_link">Feed link</string>
@@ -63,6 +66,9 @@
     <string name="undo">Undo</string>
     <string name="marked_as_read">Marked as read</string>
     <string name="marked_as_unread">Marked as unread</string>
+    <string name="expand_arrow_content_description">Expand feed group</string>
+    <string name="collapse_arrow_content_description">Collapse feed group</string>
+    <string name="mark_all_as_read_fab_content_description">Mark all as read</string>
 
     <!-- DISCOVER -->
     <string name="discover_search_label">Search Feeds</string>


### PR DESCRIPTION
This adds `contentDescription`s for the various UI elements mentioned in #422.
I would appreciate further tests and feedback on this, maybe someone with experience on accessibility topics can lean in (maybe the opener of the issue, @schulle4u)?.