### PR TITLE
Star and un-star the read articles

### DIFF
--- a/app/src/main/java/net/frju/flym/ui/entries/EntryAdapter.kt
+++ b/app/src/main/java/net/frju/flym/ui/entries/EntryAdapter.kt
@@ -18,6 +18,7 @@
 package net.frju.flym.ui.entries
 
 import android.annotation.SuppressLint
+import android.graphics.Color
 import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.View
@@ -84,7 +85,13 @@ class EntryAdapter(var displayThumbnails: Boolean, private val globalClickListen
                     date.isEnabled = !entryWithFeed.entry.read
                     date.text = entryWithFeed.entry.getReadablePublicationDate(context)
 
-                    favorite_icon.isEnabled = !entryWithFeed.entry.read || (entryWithFeed.entry.read && entryWithFeed.entry.favorite)
+                    if (entryWithFeed.entry.read) {
+                        favorite_icon.setColorFilter(Color.GRAY)
+                    }
+                    else {
+                        favorite_icon.setColorFilter(Color.WHITE)
+                    }
+
                     if (entryWithFeed.entry.favorite) {
                         favorite_icon.setImageResource(R.drawable.ic_star_24dp)
                     } else {

--- a/app/src/main/java/net/frju/flym/ui/entries/EntryAdapter.kt
+++ b/app/src/main/java/net/frju/flym/ui/entries/EntryAdapter.kt
@@ -84,7 +84,7 @@ class EntryAdapter(var displayThumbnails: Boolean, private val globalClickListen
                     date.isEnabled = !entryWithFeed.entry.read
                     date.text = entryWithFeed.entry.getReadablePublicationDate(context)
 
-                    favorite_icon.isEnabled = !entryWithFeed.entry.read
+                    favorite_icon.isEnabled = !entryWithFeed.entry.read || (entryWithFeed.entry.read && entryWithFeed.entry.favorite)
                     if (entryWithFeed.entry.favorite) {
                         favorite_icon.setImageResource(R.drawable.ic_star_24dp)
                     } else {


### PR DESCRIPTION
Hello, 
Here is a fix about the issue  #https://github.com/FredJul/Flym/issues/723. Apparently, when we change the color to say that the article has been read, we use the `isEnabled` to change the colors. The problem is that the favorites button was no longer clickable when the article was read because it was considered disable. So I changed this button with colors instead.