### PR TITLE
Handle pictures from rss "enclosures" and "media:content" tags for Entry

### DIFF
--- a/app/src/main/java/net/frju/flym/data/entities/Entry.kt
+++ b/app/src/main/java/net/frju/flym/data/entities/Entry.kt
@@ -76,7 +76,19 @@ fun SyndEntry.toDbFormat(context: Context, feed: Feed): Entry {
     }
     item.description = contents.getOrNull(0)?.value ?: description?.value
     item.link = link
+
+    enclosures?.forEach { if (it.type.contains("image")) { item.imageLink = it.url } }
+    if (item.imageLink == null) {
+        foreignMarkup?.forEach {
+            if (it.namespace?.prefix == "media" && it.name == "content") {
+                it.attributes.forEach { mc ->
+                    if (mc.name == "url") item.imageLink = mc.value
+                }
+            }
+        }
+    }
     //TODO item.imageLink = null
+
     item.author = author
 
     val date = publishedDate ?: updatedDate


### PR DESCRIPTION
Some rss feeds like : 
https://www.lemonde.fr/rss/une.xml
https://sport24.lefigaro.fr/rssfeeds/sport24-accueil.xml
use tags "enclosures" or "media:content" to specify their article picture.
Flym did not consider them and for feeds like these there was no picture in the feed list.